### PR TITLE
Add deploy parameter to declare the isopod configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ This orb is not listed. To list it again use `circleci orb unlist <namespace>/<o
 
 A currently released version is 1.0.1.
 
+## Known Issue
+
+You may get this error when pushing a new PR,
+
+```bash
+The dev version of ricardo/ric-orb@dev:alpha has expired. Dev versions of orbs are only valid for 90 days after publishing.
+```
+
+If you see this error, you need to publish a dev:alpha version manually. The fix is to run this:
+
+```bash
+circleci orb pack ./src | circleci orb validate -
+circleci orb pack ./src | circleci orb publish -  ricardo/ric-orb@dev:alpha
+```
+
 ## Usage
 
 To use the orb add this:

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -34,8 +34,9 @@ This command uses ricardo's tool **isopod** to deploy application to GKE. It is 
 
 **Parameters**:
 
-- **to :** environment to execute deployment. Valid values: *dev* and *prod*. It is passed to isopod. 
+- **to** environment to execute deployment. Valid values: *dev* and *prod*. It is passed to isopod. 
   *Default is dev.*
+- **config** the isopod configuration file. *Default is isopod.yml*
 
 Example:
 
@@ -44,6 +45,7 @@ Example:
 steps:
   - ric-orb/deploy:
       to: prod
+      config: foo/isopod.yml
 ...
 ```
 

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -4,8 +4,11 @@ parameters:
   to:
     type: string
     default: dev
+  config:
+    type: string
+    default: isopod.yml
 steps:
   - auth_gke
   - run:
       name: Deploy to cluster
-      command: isopod deploy --environment << parameters.to >>
+      command: isopod -f << parameters.config >> deploy --environment << parameters.to >>


### PR DESCRIPTION
As we already use mono repositories on github and also want to use them more often depending on the requirements, we need to have the possibility to define the isopod configuration file in the deploy command.