### PR TITLE
Add working_directory parameter

### DIFF
--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -7,8 +7,12 @@ parameters:
   config:
     type: string
     default: isopod.yml
+  working_directory:
+    type: string
+    default: .
 steps:
   - auth_gke
   - run:
       name: Deploy to cluster
       command: isopod -f << parameters.config >> deploy --environment << parameters.to >>
+      working_directory: <<parameters.working_directory>>

--- a/src/commands/quality_gate.yml
+++ b/src/commands/quality_gate.yml
@@ -8,6 +8,9 @@ parameters:
   cache_path:
     type: string
     default: ""
+  working_directory:
+    type: string
+    default: ""
   quality_checks:
     type: steps
     description: "Steps that will run quality checks"
@@ -29,7 +32,24 @@ steps:
         - restore_cache:
             name: restore the dependencies cache
             key: <<parameters.cache_name>>
-  - steps: << parameters.quality_checks >>
+  - when:
+      condition: <<parameters.working_directory>>
+      steps:
+        - run:
+            name: Installing dependencies
+            command: make install
+            working_directory: <<parameters.working_directory>>
+        - run:
+            name: Test that the app can successfully build
+            command: make build
+            working_directory: <<parameters.working_directory>>
+        - run:
+            name: Running tests
+            command: make test
+            working_directory: <<parameters.working_directory>>
+  - unless:
+      condition: <<parameters.working_directory>>
+      steps:  << parameters.quality_checks >>
   - when:
       condition:
         and: [ <<parameters.cache_name>>, <<parameters.cache_path>> ]

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -40,6 +40,9 @@ parameters:
   docker_version:
     type: string
     default: "19.03.13"
+  working_directory:
+    type: string
+    default: ""
   prebuild_steps:
     type: steps
     description: "Steps that will run before build"
@@ -90,5 +93,14 @@ steps:
             name: restore the dependencies cache
             key: <<parameters.cache_name>>
   - steps: << parameters.prebuild_steps >>
-  - steps: << parameters.build_steps >>
+  - when:
+      condition: <<parameters.working_directory>>
+      steps:
+        - run:
+            name: Build Docker image
+            command: isopod build
+            working_directory: <<parameters.working_directory>>
+  - unless:
+      condition: <<parameters.working_directory>>
+      steps: << parameters.build_steps >>
   - steps: << parameters.postbuild_steps >>

--- a/src/jobs/deploy_job.yml
+++ b/src/jobs/deploy_job.yml
@@ -53,6 +53,9 @@ parameters:
   slack_fail_branches:
     type: string
     default: master
+  working_directory:
+    type: string
+    default: .
 steps:
   - checkout
   - steps: << parameters.predeploy_steps >>
@@ -67,6 +70,7 @@ steps:
         - run: echo "default deploy"
         - deploy:
             to: <<parameters.env>>
+            working_directory: <<parameters.working_directory>>
   - steps: << parameters.postdeploy_steps >>
   - when:
       condition: << parameters.slack_notify_success >>

--- a/src/jobs/quality_gate_job.yml
+++ b/src/jobs/quality_gate_job.yml
@@ -14,6 +14,9 @@ parameters:
   cache_path:
     type: string
     default: ""
+  working_directory:
+    type: string
+    default: ""
   quality_checks:
     type: steps
     description: "Steps that will run quality checks"
@@ -35,7 +38,24 @@ steps:
         - restore_cache:
             name: restore the dependencies cache
             key: <<parameters.cache_name>>
-  - steps: << parameters.quality_checks >>
+  - when:
+      condition: <<parameters.working_directory>>
+      steps:
+        - run:
+            name: Installing dependencies
+            command: make install
+            working_directory: <<parameters.working_directory>>
+        - run:
+            name: Test that the app can successfully build
+            command: make build
+            working_directory: <<parameters.working_directory>>
+        - run:
+            name: Running tests
+            command: make test
+            working_directory: <<parameters.working_directory>>
+  - unless:
+      condition: <<parameters.working_directory>>
+      steps:  << parameters.quality_checks >>
   - when:
       condition:
         and: [ <<parameters.cache_name>>, <<parameters.cache_path>> ]


### PR DESCRIPTION
* Add working_directory parameter in order to be able to use the orb in
mono repo project

I reworked the way we are handling steps, by checking if the `working_directory` parameters is present and executing the same commands. The drawback is that you can't specify custom command if using `working_directory` parameters
Circleci doesn't allow to use parameters inside another parameters which lead me to this solution
