### PR TITLE
transform pushing to bucket into job

### DIFF
--- a/src/jobs/push_build_to_bucket_job.yml
+++ b/src/jobs/push_build_to_bucket_job.yml
@@ -1,7 +1,21 @@
 description: >
   This job sync ui assets with web assets to google storage bucket.
   Authentication is needed for creating/deleting storage objects.
+executor:
+  name: isopod
+  tag: <<parameters.isopod_version>>
+  username: <<parameters.private_hub_username>>
+  password: <<parameters.private_hub_password>>
 parameters:
+  isopod_version:
+    type: string
+    default: latest
+  private_hub_username:
+    type: string
+    default: $DOCKER_JFROG_USERNAME
+  private_hub_password:
+    type: string
+    default: $DOCKER_JFROG_PASSWORD
   bucket_name:
     type: string
     default: ${GCLOUD_WEB_ASSETS_BUCKET_NAME}


### PR DESCRIPTION
Change push_build_to_bucket into job. Currently there is no need having it as command.
As a job, it will make apps' config files smaller.