### PR TITLE
default isopod version to env var ISOPOD_VERSION

### DIFF
--- a/src/executors/isopod.yml
+++ b/src/executors/isopod.yml
@@ -7,7 +7,7 @@ docker:
       password: <<parameters.password>>
 parameters:
   tag:
-    default: latest
+    default: ${ISOPOD_VERSION}
     description: >
       Pick a specific ricardo-ch/isopod image variant.
     type: string

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -9,7 +9,7 @@ executor:
 parameters:
   isopod_version:
     type: string
-    default: latest
+    default: ${ISOPOD_VERSION}
   docker_hub_username:
     type: string
     default: $DOCKER_HUB_USERNAME

--- a/src/jobs/deploy_job.yml
+++ b/src/jobs/deploy_job.yml
@@ -8,7 +8,7 @@ executor:
 parameters:
   isopod_version:
     type: string
-    default: latest
+    default: ${ISOPOD_VERSION}
   private_hub_username:
     type: string
     default: $DOCKER_JFROG_USERNAME

--- a/src/jobs/push_build_to_bucket_job.yml
+++ b/src/jobs/push_build_to_bucket_job.yml
@@ -9,7 +9,7 @@ executor:
 parameters:
   isopod_version:
     type: string
-    default: latest
+    default: ${ISOPOD_VERSION}
   private_hub_username:
     type: string
     default: $DOCKER_JFROG_USERNAME


### PR DESCRIPTION
Setting environment variable ISOPOD_VERSION as default for isopod version. 

It is set in CircleCI contexts: prod and dev to 0.24.0. 