### PR TITLE
Fix mkdir for already existing .m2 dir

### DIFF
--- a/src/commands/maven_auth.yml
+++ b/src/commands/maven_auth.yml
@@ -10,5 +10,5 @@ steps:
   - run:
       name: Set Maven credentials
       command: |
-        mkdir ${HOME}/.m2
+        mkdir -p ${HOME}/.m2
         echo -e "${<< parameters.maven_credentials >>}" | base64 -d > ${HOME}/.m2/settings.xml


### PR DESCRIPTION
This fixes the issue `mkdir: cannot create directory ‘/home/********/.m2’: File exists`