### PR TITLE
publishing npm modules job & js executor

### DIFF
--- a/src/executors/js.yml
+++ b/src/executors/js.yml
@@ -1,0 +1,20 @@
+description: >
+  Js executor
+docker:
+  - image: cimg/node:<< parameters.node-version >>
+    auth:
+      username: <<parameters.username>>
+      password: <<parameters.password>>
+parameters:
+  node-version:
+    default: 16.15.1
+    description: Node version
+    type: string
+  username:
+    type: string
+    description: Docker hub username
+    default: $DOCKER_HUB_USERNAME
+  password:
+    type: string
+    description: Docker hub password
+    default: $DOCKER_HUB_PASSWORD

--- a/src/jobs/publish_npm_module_job.yml
+++ b/src/jobs/publish_npm_module_job.yml
@@ -1,0 +1,44 @@
+description: >
+  Publish npm module
+executor:
+  name: js
+parameters:
+  fingerprints:
+    description: SSH key fingerprint
+    type: string
+  before-publish:
+    type: steps
+    description: Steps to run before publish
+    default: []
+steps:
+  - checkout
+  - add_ssh_keys:
+      fingerprints:
+        - << parameters.fingerprints >>
+  - steps: << parameters.before-publish >>
+  - attach_workspace:
+      at: .
+  - run:
+      name: Try to extract version from last commit
+      command: |
+        lastCommitTitle=$(git log -1 --pretty="%s")
+        version=$(echo "$lastCommitTitle" | awk -F ':' '{ print tolower($1) }' | grep -Eo '^(patch|minor|major)' || true)
+        echo "VERSION_VAR=$version" >> "$BASH_ENV"
+        if [ -z "$version" ]
+        then
+          echo "No version detected. Make sure your last commit starts with patch|minor|major."
+          echo "Last commit title: '$lastCommitTitle'"
+        else
+          echo "Last commit: $lastCommitTitle"
+          echo "New '$version' version will be published..."
+        fi
+  - run:
+      name: Publish version
+      command: |
+        if [ -z "$VERSION_VAR" ]
+        then
+          echo "There will be no publish, semver was not detected"
+        else
+          echo "Publishing $VERSION_VAR version"
+          yarn np $VERSION_VAR --yolo --contents=build --no-release-draft
+        fi


### PR DESCRIPTION
Publish job was cp from working config in style-guide [here](https://github.com/ricardo-ch/style-guide-react/blob/c7444b350d9eec5a34ecc76f19e9e1855276416c/.circleci/config.yml#L196)