### PR TITLE
test runner job for jest

### DIFF
--- a/src/jobs/quality_gate_jest_test_runner_job.yml
+++ b/src/jobs/quality_gate_jest_test_runner_job.yml
@@ -1,0 +1,32 @@
+description: Runs jest tests with CircleCI parallelism
+executor: js
+parameters:
+  resource_class:
+    type: string
+    default: medium+
+  script:
+    type: string
+  globPattern:
+    type: string
+  parallelism:
+    type: integer
+    default: 4
+resource_class: << parameters.resource_class >>
+parallelism: << parameters.parallelism >>
+steps:
+  - checkout
+  - attach_workspace:
+      at: .
+  - run:
+      name: Running tests
+      command: |
+        shopt -s globstar # This is to make sure that ** is understood as pattern when globbing, e.g. /src/**/*.test.ts
+        circleci tests glob << parameters.globPattern >> | circleci tests split --split-by=timings > testing/tmp-test-list
+        yarn << parameters.script >>
+      environment:
+        JEST_JUNIT_OUTPUT_DIR: ./reports/junit
+        JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
+  - store_test_results:
+      path: ./reports/junit
+  - store_artifacts:
+      path: ./reports/junit

--- a/src/jobs/quality_gate_js_runner_job.yml
+++ b/src/jobs/quality_gate_js_runner_job.yml
@@ -1,4 +1,4 @@
-description: Run frontend tests
+description: Run any npm script (like ESLint, TS lint, phrase merge, dead code detection, ...)
 executor: js
 parameters:
   resource_class:

--- a/src/jobs/quality_gate_js_runner_job.yml
+++ b/src/jobs/quality_gate_js_runner_job.yml
@@ -1,0 +1,34 @@
+description: Run frontend tests
+executor: js
+parameters:
+  resource_class:
+    type: string
+    default: medium+
+  script:
+    type: string
+  reports_path:
+    type: string
+    default: ''
+resource_class: << parameters.resource_class >>
+steps:
+  - checkout
+  - attach_workspace:
+      at: .
+  - when:
+      condition: <<parameters.reports_path>>
+      steps:
+        - run:
+            name: Running tests
+            command: yarn << parameters.script >>
+            environment:
+              JEST_JUNIT_OUTPUT_DIR: <<parameters.reports_path>>
+        - store_test_results:
+            path: <<parameters.reports_path>>
+        - store_artifacts:
+            path: <<parameters.reports_path>>
+  - unless:
+      condition: <<parameters.reports_path>>
+      steps:
+        - run:
+            name: Running tests
+            command: yarn << parameters.script >>


### PR DESCRIPTION
Jobs for frontend quality gating

- `quality_gate_jest_test_runner_job.yml` - runs jest tests with CircleCi parallelism
- `quality_gate_js_runner_job.yml` - runs all other js tests, e.g. lint, ts

Both jobs are proved to be working in `marketplace-frontend-app` [dashoboard](https://app.circleci.com/pipelines/github/ricardo-ch/marketplace-frontend-app?branch=speedup-tests)