### PR TITLE
adapt examples so that they support github status checks on monorepos

### DIFF
--- a/src/examples/java_monorepo_setup.yml
+++ b/src/examples/java_monorepo_setup.yml
@@ -29,6 +29,7 @@ usage:
     setup:
       jobs:
         - path-filtering/filter:
+            # FIXME: replace master branch name with your actual master/main branch name
             base-revision: master
             # 3-column, whitespace-delimited mapping. One mapping per line:
             # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>

--- a/src/examples/java_monorepo_setup.yml
+++ b/src/examples/java_monorepo_setup.yml
@@ -32,8 +32,8 @@ usage:
             base-revision: master
             # 3-column, whitespace-delimited mapping. One mapping per line:
             # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
-            # FIXME: replace common module path(s) with your actual paths
-            # FIXME: replace app paths and names with your actual names/paths
+            # FIXME: replace common module paths with your actual paths
+            # FIXME: replace app paths and suffix with your actual paths/names
             mapping: |
               .circleci/.*|.mvn/.*|pom.xml|common/.* modified-common true
               app1/.* modified-app1 true

--- a/src/examples/java_monorepo_workflows.yml
+++ b/src/examples/java_monorepo_workflows.yml
@@ -59,7 +59,9 @@ usage:
           - not: << pipeline.parameters.modified-app1 >>
           - not: << pipeline.parameters.modified-common >>
       jobs:
-        # github status check typically checks this job (name must match name of the actual build job for the app!)
+        # github status check typically checks this job
+        # NOTE: job name must match name of apps actual build job so that github can stay agnostic!
+        # the idea is that, depending on whether there were changes to the app or not, github either considers this no-op here or the actual build status (without knowing which)
         - ric-orb/no_op:
             # FIXME: replace suffix with your actual app name (name must match name of the actual build job for the app!)
             name: 'maven-build-test-app1'
@@ -72,7 +74,9 @@ usage:
           - not: << pipeline.parameters.modified-app2 >>
           - not: << pipeline.parameters.modified-common >>
       jobs:
-        # github status check typically checks this job (name must match name of the actual build job for the app!)
+        # github status check typically checks this job
+        # NOTE: job name must match name of apps actual build job so that github can stay agnostic!
+        # the idea is that, depending on whether there were changes to the app or not, github either considers this no-op here or the actual build status (without knowing which)
         - ric-orb/no_op:
             # FIXME: replace suffix with your actual app name (name must match name of the actual build job for the app!)
             name: 'maven-build-test-app2'

--- a/src/examples/java_monorepo_workflows.yml
+++ b/src/examples/java_monorepo_workflows.yml
@@ -37,6 +37,12 @@ usage:
     # FIXME: replace value with your actual repo name
     cache_key_prefix: my-repo
 
+  # NOTE: job name of no-op build jobs must match respective name of apps actual build jobs so that github can stay agnostic!
+  # FIXME: replace suffix with your actual app name
+  maven-build-test-app1: &maven-build-test-app1 'maven-build-test-app1'
+  # FIXME: replace suffix with your actual app name
+  maven-build-test-app2: &maven-build-test-app2 'maven-build-test-app2'
+
   workflows:
     version: 2
 
@@ -60,11 +66,10 @@ usage:
           - not: << pipeline.parameters.modified-common >>
       jobs:
         # github status check typically checks this job
-        # NOTE: job name must match name of apps actual build job so that github can stay agnostic!
         # the idea is that, depending on whether there were changes to the app or not, github either considers this no-op here or the actual build status (without knowing which)
         - ric-orb/no_op:
             # FIXME: replace suffix with your actual app name (name must match name of the actual build job for the app!)
-            name: 'maven-build-test-app1'
+            name: *maven-build-test-app1
 
     # FIXME: replace infix with your actual app name
     no-app2-change:
@@ -75,11 +80,10 @@ usage:
           - not: << pipeline.parameters.modified-common >>
       jobs:
         # github status check typically checks this job
-        # NOTE: job name must match name of apps actual build job so that github can stay agnostic!
         # the idea is that, depending on whether there were changes to the app or not, github either considers this no-op here or the actual build status (without knowing which)
         - ric-orb/no_op:
-            # FIXME: replace suffix with your actual app name (name must match name of the actual build job for the app!)
-            name: 'maven-build-test-app2'
+            # FIXME: replace suffix with your actual app name
+            name: *maven-build-test-app2
 
     ###########################################################################
     # workflow for maven module 'app1'
@@ -92,10 +96,10 @@ usage:
           - << pipeline.parameters.modified-common >>
 
       jobs:
+        # github status check typically checks this job
         - ric-orb/maven_build_test:
-            # github status check typically checks this job
             # FIXME: replace suffix with your actual app name
-            name: 'maven-build-test-app1'
+            name: *maven-build-test-app1
             context: dev
             # FIXME: replace value with your actual app path
             path: 'app1'
@@ -118,7 +122,7 @@ usage:
             <<: *cfg-isopod-version
             requires:
               # FIXME: replace suffix with your actual app name
-              - maven-build-test-app1
+              - *maven-build-test-app1
               # note semantic of 'requires': on master this is ignored
               - approve_deploy_dev_branch
 
@@ -162,10 +166,10 @@ usage:
           - << pipeline.parameters.modified-common >>
 
       jobs:
+        # github status check typically checks this job
         - ric-orb/maven_build_test:
-            # github status check typically checks this job
             # FIXME: replace suffix with your actual app name
-            name: 'maven-build-test-app2'
+            name: *maven-build-test-app2
             context: dev
             # FIXME: replace value with your actual app path
             path: 'app2'
@@ -188,7 +192,7 @@ usage:
             <<: *cfg-isopod-version
             requires:
               # FIXME: replace suffix with your actual app name
-              - maven-build-test-app2
+              - *maven-build-test-app2
               # note semantic of 'requires': on master this is ignored
               - approve_deploy_dev_branch
 

--- a/src/examples/java_monorepo_workflows.yml
+++ b/src/examples/java_monorepo_workflows.yml
@@ -46,17 +46,6 @@ usage:
   workflows:
     version: 2
 
-    no-code-change:
-      when:
-        and:
-          # FIXME: replace suffix with your actual app name
-          - not: << pipeline.parameters.modified-app1 >>
-          # FIXME: replace suffix with your actual app name
-          - not: << pipeline.parameters.modified-app2 >>
-          - not: << pipeline.parameters.modified-common >>
-      jobs:
-        - ric-orb/no_op
-
     # FIXME: replace infix with your actual app name
     no-app1-change:
       when:

--- a/src/examples/java_monorepo_workflows.yml
+++ b/src/examples/java_monorepo_workflows.yml
@@ -22,11 +22,11 @@ usage:
     modified-common:
       type: boolean
       default: false
-    # FIXME: replace with your actual app name
+    # FIXME: replace suffix with your actual app name
     modified-app1:
       type: boolean
       default: false
-    # FIXME: replace with your actual app name
+    # FIXME: replace suffix with your actual app name
     modified-app2:
       type: boolean
       default: false
@@ -34,7 +34,7 @@ usage:
   cfg-isopod-version: &cfg-isopod-version
     isopod_version: '0.29.1'
   cfg-cache-key-prefix: &cfg-cache-key-prefix
-    # FIXME: replace with your actual repo name
+    # FIXME: replace value with your actual repo name
     cache_key_prefix: my-repo
 
   workflows:
@@ -43,17 +43,44 @@ usage:
     no-code-change:
       when:
         and:
+          # FIXME: replace suffix with your actual app name
           - not: << pipeline.parameters.modified-app1 >>
+          # FIXME: replace suffix with your actual app name
           - not: << pipeline.parameters.modified-app2 >>
           - not: << pipeline.parameters.modified-common >>
-
       jobs:
         - ric-orb/no_op
+
+    # FIXME: replace infix with your actual app name
+    no-app1-change:
+      when:
+        and:
+          # FIXME: replace suffix with your actual app name
+          - not: << pipeline.parameters.modified-app1 >>
+          - not: << pipeline.parameters.modified-common >>
+      jobs:
+        # github status check typically checks this job (name must match name of the actual build job for the app!)
+        - ric-orb/no_op:
+            # FIXME: replace suffix with your actual app name (name must match name of the actual build job for the app!)
+            name: 'maven-build-test-app1'
+
+    # FIXME: replace infix with your actual app name
+    no-app2-change:
+      when:
+        and:
+          # FIXME: replace suffix with your actual app name
+          - not: << pipeline.parameters.modified-app2 >>
+          - not: << pipeline.parameters.modified-common >>
+      jobs:
+        # github status check typically checks this job (name must match name of the actual build job for the app!)
+        - ric-orb/no_op:
+            # FIXME: replace suffix with your actual app name (name must match name of the actual build job for the app!)
+            name: 'maven-build-test-app2'
 
     ###########################################################################
     # workflow for maven module 'app1'
     ###########################################################################
-    # FIXME: replace with your actual app name
+    # FIXME: replace name with your actual app name
     app1:
       when:
         or:
@@ -62,9 +89,11 @@ usage:
 
       jobs:
         - ric-orb/maven_build_test:
-            name: 'maven-build-test'
+            # github status check typically checks this job
+            # FIXME: replace suffix with your actual app name
+            name: 'maven-build-test-app1'
             context: dev
-            # FIXME: replace with your actual app path
+            # FIXME: replace value with your actual app path
             path: 'app1'
             <<: *cfg-cache-key-prefix
             executor: maven_docker
@@ -80,11 +109,12 @@ usage:
         - ric-orb/build_push_image:
             name: 'build-push-image'
             context: dev
-            # FIXME: replace with your actual app path
+            # FIXME: replace value with your actual app path
             path: 'app1'
             <<: *cfg-isopod-version
             requires:
-              - maven-build-test
+              # FIXME: replace suffix with your actual app name
+              - maven-build-test-app1
               # note semantic of 'requires': on master this is ignored
               - approve_deploy_dev_branch
 
@@ -96,7 +126,7 @@ usage:
         - ric-orb/deploy_job:
             name: 'deploy-dev'
             context: dev
-            # FIXME: replace with your actual app path
+            # FIXME: replace value with your actual app path
             path: 'app1'
             <<: *cfg-isopod-version
             env: 'dev'
@@ -106,7 +136,7 @@ usage:
         - ric-orb/deploy_job:
             name: 'deploy-prod'
             context: prod
-            # FIXME: replace with your actual app path
+            # FIXME: replace value with your actual app path
             path: 'app1'
             <<: *cfg-isopod-version
             env: 'prod'
@@ -120,7 +150,7 @@ usage:
     ###########################################################################
     # maven module: 'app2'
     ###########################################################################
-    # FIXME: replace with your actual app name
+    # FIXME: replace name with your actual app name
     app2:
       when:
         or:
@@ -129,9 +159,11 @@ usage:
 
       jobs:
         - ric-orb/maven_build_test:
-            name: 'maven-build-test'
+            # github status check typically checks this job
+            # FIXME: replace suffix with your actual app name
+            name: 'maven-build-test-app2'
             context: dev
-            # FIXME: replace with your actual app path
+            # FIXME: replace value with your actual app path
             path: 'app2'
             <<: *cfg-cache-key-prefix
 #            executor: maven_docker
@@ -147,11 +179,12 @@ usage:
         - ric-orb/build_push_image:
             name: 'build-push-image'
             context: dev
-            # FIXME: replace with your actual app path
+            # FIXME: replace value with your actual app path
             path: 'app2'
             <<: *cfg-isopod-version
             requires:
-              - maven-build-test
+              # FIXME: replace suffix with your actual app name
+              - maven-build-test-app2
               # note semantic of 'requires': on master this is ignored
               - approve_deploy_dev_branch
 
@@ -163,7 +196,7 @@ usage:
         - ric-orb/deploy_job:
             name: 'deploy-dev'
             context: dev
-            # FIXME: replace with your actual app path
+            # FIXME: replace value with your actual app path
             path: 'app2'
             <<: *cfg-isopod-version
             env: 'dev'
@@ -173,7 +206,7 @@ usage:
         - ric-orb/deploy_job:
             name: 'deploy-prod'
             context: prod
-            # FIXME: replace with your actual app path
+            # FIXME: replace value with your actual app path
             path: 'app2'
             <<: *cfg-isopod-version
             env: 'prod'

--- a/src/examples/java_monorepo_workflows.yml
+++ b/src/examples/java_monorepo_workflows.yml
@@ -32,7 +32,7 @@ usage:
       default: false
 
   cfg-isopod-version: &cfg-isopod-version
-    isopod_version: '0.29.1'
+    isopod_version: '0.29.4'
   cfg-cache-key-prefix: &cfg-cache-key-prefix
     # FIXME: replace value with your actual repo name
     cache_key_prefix: my-repo

--- a/src/examples/java_singleapprepo.yml
+++ b/src/examples/java_singleapprepo.yml
@@ -28,8 +28,8 @@ usage:
     # FIXME: replace name with your actual app name
     java_single_app_repo:
       jobs:
+        # github status check typically checks this job
         - ric-orb/maven_build_test:
-            # github status check typically checks this job
             name: 'maven-build-test'
             context: dev
             <<: *cfg-cache-key-prefix

--- a/src/examples/java_singleapprepo.yml
+++ b/src/examples/java_singleapprepo.yml
@@ -19,16 +19,17 @@ usage:
   cfg-isopod-version: &cfg-isopod-version
     isopod_version: '0.29.1'
   cfg-cache-key-prefix: &cfg-cache-key-prefix
-    # FIXME: replace with your actual repo name
+    # FIXME: replace value with your actual repo name
     cache_key_prefix: my-repo
 
   workflows:
     version: 2
 
-    # FIXME: replace with your actual app name
+    # FIXME: replace name with your actual app name
     java_single_app_repo:
       jobs:
         - ric-orb/maven_build_test:
+            # github status check typically checks this job
             name: 'maven-build-test'
             context: dev
             <<: *cfg-cache-key-prefix

--- a/src/examples/java_singleapprepo.yml
+++ b/src/examples/java_singleapprepo.yml
@@ -17,7 +17,7 @@ usage:
     ric-orb: ricardo/ric-orb@2
 
   cfg-isopod-version: &cfg-isopod-version
-    isopod_version: '0.29.1'
+    isopod_version: '0.29.4'
   cfg-cache-key-prefix: &cfg-cache-key-prefix
     # FIXME: replace value with your actual repo name
     cache_key_prefix: my-repo

--- a/src/examples/service_one.yml
+++ b/src/examples/service_one.yml
@@ -10,11 +10,11 @@ usage:
 
   references:
     deploy_cfg: &deploy_cfg
-      isopod_version: 0.29.1
+      isopod_version: 0.29.4
       private_hub_username: $PDOCKER_USERNAME
       private_hub_password: $PDOCKER_PASSWORD
     build_cfg: &build_cfg
-      isopod_version: 0.29.1
+      isopod_version: 0.29.4
       private_hub_username: $PDOCKER_USERNAME
       private_hub_password: $PDOCKER_PASSWORD
       docker_hub_username: $MY_DOCKER_HUB_USERNAME

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -145,7 +145,7 @@ Custom properties:
 jobs:
 ...
   - ric-orb/build_push_image:
-      isopod_version: "0.29.1"
+      isopod_version: "0.29.4"
       docker_version: "19.03.13"
       private_hub_username: ${PDOCKER_USERNAME}
       private_hub_password: ${PDOCKER_PASSWORD}
@@ -169,7 +169,7 @@ jobs:
       context: dev
       path: "myapp"
       docker_version: "19.03.13"
-      isopod_version: "0.29.1"
+      isopod_version: "0.29.4"
       requires:
         - maven_build_test
 ...
@@ -208,7 +208,7 @@ jobs:
 ...
   - ric-orb/deploy_job:
       name: prod
-      isopod_version: 0.29.1
+      isopod_version: 0.29.4
       private_hub_username: $PDOCKER_USERNAME
       private_hub_password: $PDOCKER_PASSWORD
       env: prod
@@ -276,7 +276,7 @@ jobs:
   - ric-orb/deploy_job:
       context: dev
       path: "myapp"
-      isopod_version: "0.29.1"
+      isopod_version: "0.29.4"
       env: "dev"
       requires:
         - build_push_image


### PR DESCRIPTION
extend examples as sketched in https://github.com/ricardo-ch/incidents-api/pull/181
addresses this [slack discussion](https://ricardo-ch.slack.com/archives/C34DE9XQ8/p1658316530169269) regarding how to do github status checks on monorepos

goal is to have a designated job (name) for each app that is executed in every case, which allows github status check to work properly (note: it does not deal gracefully with "missing" jobs unfortunately)

---

personal concern:
what im really scared of is the coupling between github repo- / -branch config and circleCI-config, which is totally by custom convention (i.e. you 100% dont notice if you break it, and it might not even be visible on the branch/build because the change might introduce a regression that is only visible later when a single app is touched in another branch :cry:)