### PR TITLE
Change isopod working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ circleci orb pack ./src | circleci orb publish -  ricardo/ric-orb@dev:alpha
 To use the orb add this:
 ```yaml
 orbs:
-    ric-orb: ricardo/ric-orb@1.7.0
+    ric-orb: ricardo/ric-orb@3
 ```
 
 to your `.circleci/config.yml` file.

--- a/src/examples/java_monorepo_workflows.yml
+++ b/src/examples/java_monorepo_workflows.yml
@@ -16,7 +16,7 @@ usage:
 
   orbs:
     compliance: ricardo/compliance-orb@2
-    ric-orb: ricardo/ric-orb@2
+    ric-orb: ricardo/ric-orb@3
 
   parameters:
     modified-common:

--- a/src/examples/java_singleapprepo.yml
+++ b/src/examples/java_singleapprepo.yml
@@ -14,7 +14,7 @@ usage:
 
   orbs:
     compliance: ricardo/compliance-orb@2
-    ric-orb: ricardo/ric-orb@2
+    ric-orb: ricardo/ric-orb@3
 
   cfg-isopod-version: &cfg-isopod-version
     isopod_version: '0.29.4'

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -88,7 +88,7 @@ jobs:
 
 **Parameters**:
 
-- **path** Path to directory containing isopod.yml file. Default is `.`
+- **path** Path to directory containing isopod.yml file. NOTE: this directory will be the working directory for isopod (i.e. dockerfile is also expected there, and should be executable directly from that directory). Default is `.`
 - **isopod_version** isopod version in executor. Not required. Default is *latest*
 - **docker_hub_username** username for public docker registry(Docker Hub), default is value of context variable *$DOCKER_HUB_USERNAME*
 - **docker_hub_password** password for public docker registry(Docker Hub), default is value of context variable *$DOCKER_HUB_PASSWORD*

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -85,5 +85,5 @@ steps:
       at: .
   - steps: << parameters.prebuild_steps >>
   - build_push:
-      config: << parameters.path >>/isopod.yml
+      work_dir: << parameters.path >>
   - steps: << parameters.postbuild_steps >>


### PR DESCRIPTION
‼️ this is a breaking change ‼️ 

change the working directory of the build_push_image job (isopod) in case a submodule path is set.
the underlying assumption is that in the stereotypical case the path is a module directory containing the isopod file as well as the dockerfile, both of which agnostic to their nesting

advantage over current implementation:
- in case of monorepo, the docker build is executed from project root, thus the dockerfile must be path aware! with the new implementation the dockerfile can be agnostic because isopod works in that directory