### PR TITLE
fix cache key for maven artifact cache in case of monorepo

### DIFF
--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -156,7 +156,7 @@ This command execute install, build, test make commands. So, to execute it there
 
 - **cache_name** Not required. If not specified cache will not be used/created.
 - **cache_path** Not required. If not specified cache will not be created.
-- **quality_checks** is a list of steps to run. By default they are:
+- **quality_checks** is a list of steps to run. By default this is:
 
 ```yaml
 quality_checks:
@@ -187,7 +187,7 @@ steps:
 **Parameters**:
 
 - **branches** The list of comma separated branches for which notification should be sent. Default is *master*.
-- **webhook** is the slack webhook to channel where notification is sent. Default is stored in context/environment variable SLACK_WEBHOOK(for channel circleci-deployments). Specify only if need to veride.
+- **webhook** is the slack webhook to channel where notification is sent. Default is stored in context/environment variable SLACK_WEBHOOK (for channel circleci-deployments). Specify only if you need to override.
 
 This command sends notification for branches to the target webhook when job fails. This uses [the slack orb](https://circleci.com/developer/orbs/orb/circleci/slack?version=3.4.2).
 
@@ -228,11 +228,11 @@ steps:
 **Name**: maven_cache_artifacts
 
 **Parameters**:
-- **prefix** Prefix for the cache-key (used in combination with checksum of *pom.xml*)
+- **prefix** Prefix for the cache-key (used in combination with and checksum of *pom.xml* as well as *path*)
+- **path** Path of maven module (or "." for single-app-repo') for the cache-key (used in combination with *prefix* and checksum of *pom.xml*). Default: "*.*"
 
 Example:
 
-Note that you typically want to use a shared prefix for the entire repository in case of monorepo, because otherwise builds of the individual apps will not utilize a shared cache.
 ```yaml
 ...
 steps:
@@ -241,20 +241,40 @@ steps:
 ...
 ```
 
+Note that you typically want to use a shared prefix for the entire repository in case of monorepo, because this way the individual apps can fall back to each other's cache.
+```yaml
+...
+steps:
+  - ric-orb/maven_cache_artifacts:
+      prefix: "my-monorepo"
+      path: "app1"
+...
+```
+
 ### Command to restore maven artifacts from cache for Java applications
 **Name**: maven_restore_artifacts
 
 **Parameters**:
-- **prefix** Prefix for the cache-key (used in combination with checksum of *pom.xml*); no-op with blank prefix. Default: *blank*
+- **prefix** Prefix for the cache-key (used in combination with checksum of *pom.xml* as well as *path*); no-op with blank prefix. Default: *blank*
+- **path** Path of maven module (or "." for single-app-repo') for the cache-key (used in combination with *prefix* and checksum of *pom.xml*). Default: "*.*"
 
 Example:
 
-Note that you typically want to use a shared prefix for the entire repository in case of monorepo, because otherwise builds of the individual apps will not utilize a shared cache.
 ```yaml
 ...
 steps:
   - ric-orb/maven_restore_artifacts:
       prefix: "myrepo"
+...
+```
+
+Note that you typically want to use a shared prefix for the entire repository in case of monorepo, because this way the individual apps can fall back to each other's cache.
+```yaml
+...
+steps:
+  - ric-orb/maven_cache_artifacts:
+      prefix: "my-monorepo"
+      path: "app1"
 ...
 ```
 

--- a/src/commands/maven_cache_artifacts.yml
+++ b/src/commands/maven_cache_artifacts.yml
@@ -6,9 +6,13 @@ parameters:
   prefix:
     description: 'Prefix for the cache-key (used in combination with checksum of pom.xml)'
     type: string
+  path:
+    description: 'Path of maven module for the app, or "." for single-app-repo'
+    type: string
+    default: '.'
 
 steps:
   - save_cache:
       paths:
         - ~/.m2
-      key: << parameters.prefix >>-{{ checksum "pom.xml" }}
+      key: << parameters.prefix >>-{{ checksum "pom.xml" }}-<< parameters.path >>

--- a/src/commands/maven_restore_artifacts.yml
+++ b/src/commands/maven_restore_artifacts.yml
@@ -7,6 +7,10 @@ parameters:
     description: 'Prefix for the cache-key (used in combination with checksum of pom.xml); no-op with blank prefix'
     type: string
     default: ''
+  path:
+    description: 'Path of maven module for the app, or "." for single-app-repo'
+    type: string
+    default: '.'
 
 steps:
   - when:
@@ -14,5 +18,6 @@ steps:
       steps:
         - restore_cache:
             keys:
+              - << parameters.prefix >>-{{ checksum "pom.xml" }}-<< parameters.path >>
               - << parameters.prefix >>-{{ checksum "pom.xml" }}
               - << parameters.prefix >>-

--- a/src/jobs/maven_build_test.yml
+++ b/src/jobs/maven_build_test.yml
@@ -25,6 +25,7 @@ steps:
   - maven_auth
   - maven_restore_artifacts:
       prefix: << parameters.cache_key_prefix >>
+      path: << parameters.path >>
   - login_docker_registry:
       url: ${DOCKER_JFROG_REGISTRY_URL}
       username: ${DOCKER_JFROG_USERNAME}
@@ -33,5 +34,6 @@ steps:
       path: << parameters.path >>
   - maven_cache_artifacts:
       prefix: << parameters.cache_key_prefix >>
+      path: << parameters.path >>
   - maven_save_output:
       path: << parameters.path >>


### PR DESCRIPTION
problem: if cache for cache-key exists, circleCI will not update the cache
- for classic repos this is fine: hash of pom is part of the cache-key, and we only need updates to .m2 if the pom changes, thus cache always contains all we need
  - workflow for the single app in the repo
    - restoring cache-key `prefix-{{hash "pom.xml"}}`
    - building the single app
    - caching `.m2`
- for mono-repos this is **problematic**: hash of pom is part of the cache-key, but cache is created with build of each individual module. since the modules are typically built individually, so the .m2 is often missing artifacts that are required for the other app(s).
  - workflow for app1 in the monorepo
    - restoring cache-key `prefix-{{hash "pom.xml"}}`
    - building app1
    - caching `.m2`
  - workflow for app2 in the monorepo
    - restoring cache-key `prefix-{{hash "pom.xml"}}`
    - building app2
    - caching `.m2`

fix: change the cache key by adding a postfix with the app path (or "." for single app repos) so we get individual keys for each app in the mono-repo (i.e. individual caches)
- for classic and monorepos:
  - workflow for appN
    - restoring cache-key `prefix-{{hash "pom.xml"}}-appNpath`
    - building appN
    - caching `.m2`
