### PR TITLE
js - push_build_to_bucket_job changes

### DIFF
--- a/src/commands/js_restore_build_outputs.yml
+++ b/src/commands/js_restore_build_outputs.yml
@@ -1,4 +1,4 @@
-description: Attach build files from workspace
+description: Attach build files from environment specific directory in workspace
 parameters:
   build_env:
     type: enum

--- a/src/commands/js_restore_build_outputs.yml
+++ b/src/commands/js_restore_build_outputs.yml
@@ -1,0 +1,15 @@
+description: Attach build files from workspace
+parameters:
+  build_env:
+    type: enum
+    enum: [ 'beta', 'prod']
+    default: beta
+steps: 
+  - attach_workspace:
+      name: WORKSPACE - Attaching from /<< parameters.build_env >>
+      at: .
+  - run: 
+      name: WORKSPACE - Copy files to root
+      command: |
+        cp -a << parameters.build_env >>/. .
+        rm -rf << parameters.build_env >>

--- a/src/commands/js_restore_build_outputs.yml
+++ b/src/commands/js_restore_build_outputs.yml
@@ -4,11 +4,11 @@ parameters:
     type: enum
     enum: [ 'beta', 'prod']
     default: beta
-steps: 
+steps:
   - attach_workspace:
       name: WORKSPACE - Attaching from /<< parameters.build_env >>
       at: .
-  - run: 
+  - run:
       name: WORKSPACE - Copy files to root
       command: |
         cp -a << parameters.build_env >>/. .

--- a/src/commands/js_save_build_outputs.yml
+++ b/src/commands/js_save_build_outputs.yml
@@ -1,0 +1,17 @@
+description: Persist build files to workspace
+parameters:
+  build_env:
+    type: enum
+    enum: [ 'beta', 'prod' ]
+    default: beta
+steps:
+  - run: 
+      name: WORKSPACE - Create /<< parameters.build_env >> folder
+      command: |
+        mkdir -p << parameters.build_env >>
+        cp -r build .next << parameters.build_env >>
+  - persist_to_workspace:
+      name: WORKSPACE - persisting to /<< parameters.build_env >>
+      root: .
+      paths:
+        - << parameters.build_env >>

--- a/src/commands/js_save_build_outputs.yml
+++ b/src/commands/js_save_build_outputs.yml
@@ -5,7 +5,7 @@ parameters:
     enum: [ 'beta', 'prod' ]
     default: beta
 steps:
-  - run: 
+  - run:
       name: WORKSPACE - Create /<< parameters.build_env >> folder
       command: |
         mkdir -p << parameters.build_env >>

--- a/src/commands/js_save_build_outputs.yml
+++ b/src/commands/js_save_build_outputs.yml
@@ -1,4 +1,4 @@
-description: Persist build files to workspace
+description: Persist build files to environment specific directory in workspace
 parameters:
   build_env:
     type: enum

--- a/src/jobs/push_build_to_bucket_job.yml
+++ b/src/jobs/push_build_to_bucket_job.yml
@@ -26,9 +26,13 @@ parameters:
     type: string
   source:
     type: string
+  build_env:
+    type: enum
+    enum: [ 'beta', 'prod']
+    default: beta
 steps:
-  - attach_workspace:
-      at: .
+  - js_restore_build_outputs:
+      build_env: << parameters.build_env >>
   - run:
       name: Authenticate to GKE
       command: |


### PR DESCRIPTION
Introduce command for` persisting to workspace` and `attaching workspace` in a safe way, where data could be stored in separate folders  of workspace (beta or prod). This way we are sure that running 2 jobs in parallel, but for different contexts will not overwrite each others workspaces.

Use this new command in `push_build_to_bucket_job`.