### PR TITLE
Adding local_port to port forward, fix missing image_name for docker_build

### DIFF
--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -33,6 +33,7 @@ steps:
 Build and push the docker image with docker.
 
 **Parameters**:
+- **image_name**: The Docker image name (without the path, e.g. search-solr)
 - **work_dir**: Working directory for the command. Deafult is *"."*
 
 Example:
@@ -41,6 +42,7 @@ Example:
 #...
 steps:
   - ric-orb/docker_build_push:
+      image_name: my_image
       work_dir: my_maven_module
 #...
 ```

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -103,7 +103,7 @@ steps:
 **Parameters**:
 - **target**: service/pod to which traffic is forwarded
 - **port**: service/pod port to portforward
-- **local_port**: (optional) service/pod port to portforward on the LOCAL (CircleCI) side. If missing, it is the same than port
+- **local_port**: (optional) service/pod port to portforward on the LOCAL (CircleCI) side. If missing or 0, it is the same as port
 - **namespace**: k8s namespace where service/pod is located
 - **context**: k8s context.
 

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -101,6 +101,7 @@ steps:
 **Parameters**:
 - **target**: service/pod to which traffic is forwarded
 - **port**: service/pod port to portforward
+- **local_port**: (optional) service/pod port to portforward on the LOCAL (CircleCI) side. If missing, it is the same than port
 - **namespace**: k8s namespace where service/pod is located
 - **context**: k8s context.
 

--- a/src/commands/docker_build_push.yml
+++ b/src/commands/docker_build_push.yml
@@ -2,6 +2,8 @@ description: >
   Build the docker image with docker.
 
 parameters:
+  image_name:
+    type: string
   work_dir:
     type: string
     default: .
@@ -9,7 +11,7 @@ parameters:
 steps:
   - run:
       name: 'docker build'
-      command: docker build -t ric-docker.jfrog.io/ricardo-ch/search-solr:${CIRCLE_BRANCH}-${CIRCLE_SHA1} .
+      command: docker build -t ric-docker.jfrog.io/ricardo-ch/<< parameters.image_name >>:${CIRCLE_BRANCH}-${CIRCLE_SHA1} .
   - run:
       name: 'docker push'
-      command: docker push ric-docker.jfrog.io/ricardo-ch/search-solr:${CIRCLE_BRANCH}-${CIRCLE_SHA1}
+      command: docker push ric-docker.jfrog.io/ricardo-ch/<< parameters.image_name >>:${CIRCLE_BRANCH}-${CIRCLE_SHA1}

--- a/src/commands/gke_port_forward.yml
+++ b/src/commands/gke_port_forward.yml
@@ -15,7 +15,7 @@ parameters:
   context:
     type: string
 steps:
-  # if local_port should be the same than port
+  # if 0, local_port should be the same as port
   - when:
       condition:
         equal: [ 0, <<parameters.local_port>> ]
@@ -27,7 +27,7 @@ steps:
         - run:
             name: Wait for port forwarding setup completion
             command: dockerize -wait tcp://localhost:<<parameters.port>> -timeout 60s
-  # if local_port has a value
+  # if local_port has a value, use it
   - unless:
       condition:
         equal: [ 0, <<parameters.local_port>> ]

--- a/src/commands/gke_port_forward.yml
+++ b/src/commands/gke_port_forward.yml
@@ -7,15 +7,35 @@ parameters:
     type: string
   port:
     type: integer
+  local_port:
+    type: integer
+    default: 0
   namespace:
     type: string
   context:
     type: string
 steps:
-  - run:
-      background: true
-      name: Setup port forwarding to target
-      command: kubectl port-forward --context <<parameters.context>> -n <<parameters.namespace>> <<parameters.target>> <<parameters.port>>
-  - run:
-      name: Wait for port forwarding setup completion
-      command: dockerize -wait tcp://localhost:<<parameters.port>> -timeout 60s
+  # if local_port should be the same than port
+  - when:
+      condition:
+        equal: [ 0, <<parameters.local_port>> ]
+      steps:
+        - run:
+            background: true
+            name: Setup port forwarding to target
+            command: kubectl port-forward --context <<parameters.context>> -n <<parameters.namespace>> <<parameters.target>> <<parameters.port>>
+        - run:
+            name: Wait for port forwarding setup completion
+            command: dockerize -wait tcp://localhost:<<parameters.port>> -timeout 60s
+  # if local_port has a value
+  - unless:
+      condition:
+        equal: [ 0, <<parameters.local_port>> ]
+      steps:
+        - run:
+            background: true
+            name: Setup port forwarding to target
+            command: kubectl port-forward --context <<parameters.context>> -n <<parameters.namespace>> <<parameters.target>> <<parameters.local_port>>:<<parameters.port>>
+        - run:
+            name: Wait for port forwarding setup completion
+            command: dockerize -wait tcp://localhost:<<parameters.local_port>> -timeout 60s

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -81,6 +81,7 @@ jobs:
 **Name**: docker_build_push
 
 **Parameters**:
+- **image_name**: The Docker image name (without the path, e.g. search-solr)
 - **path**: Path to directory containing dockerfile (also working directory). Default is *"."*
 - **docker_hub_username**: Docker hub credentials. Default is context variable *$DOCKER_HUB_USERNAME*
 - **docker_hub_password**: Docker hub credentials. Default is context variable *$DOCKER_HUB_PASSWORD*
@@ -99,7 +100,8 @@ Minimal
 #...
 jobs:
   # ...
-  - ric-orb/docker_build_push
+  - ric-orb/docker_build_push:
+      image_name: my_image
 #...
 ```
 
@@ -109,6 +111,7 @@ For a specific (maven) module:
 jobs:
   # ...
   - ric-orb/docker_build_push:
+      image_name: my_image
       path: my_maven_module
 #...
 ```

--- a/src/jobs/docker_build_push.yml
+++ b/src/jobs/docker_build_push.yml
@@ -9,6 +9,9 @@ executor:
   password: <<parameters.private_hub_password>>
 
 parameters:
+  image_name:
+    description: 'The Docker image name (without the path, e.g. search-solr)'
+    type: string
   path:
     description: 'Path to directory containing dockerfile (also working directory)'
     type: string
@@ -52,4 +55,5 @@ steps:
   - attach_workspace:
       at: .
   - docker_build_push:
+      image_name: << parameters.image_name >>
       work_dir: << parameters.path >>


### PR DESCRIPTION
- adding optional `local_port` option for `gke_port_forward`, this is needed because some flows port-forward to more than one service
- fixing bug in `docker_build_push`: it had image name hardcoded to `search-solr`

Example of usage:
- https://github.com/ricardo-ch/search-solr-admin/pull/48