### PR TITLE
Configurable executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ circleci orb pack ./src | circleci orb publish -  ricardo/ric-orb@dev:alpha
 To use the orb add this:
 ```yaml
 orbs:
-    ric-orb: ricardo/ric-orb@4
+    ric-orb: ricardo/ric-orb@5
 ```
 
 to your `.circleci/config.yml` file.

--- a/src/examples/go_monorepo_workflows.yml
+++ b/src/examples/go_monorepo_workflows.yml
@@ -17,7 +17,7 @@ usage:
   orbs:
     compliance: ricardo/compliance-orb@2
     go: circleci/go@1.7.1
-    ric-orb: ricardo/ric-orb@4
+    ric-orb: ricardo/ric-orb@5
 
   #FIXME: isopod version that you want to use
   cfg-isopod-version: &cfg-isopod-version

--- a/src/examples/go_singlerepo.yml
+++ b/src/examples/go_singlerepo.yml
@@ -16,7 +16,7 @@ usage:
   orbs:
     go: circleci/go@1.7.1
     compliance: ricardo/compliance-orb@2
-    ric-orb: ricardo/ric-orb@4
+    ric-orb: ricardo/ric-orb@5
 
   cfg-isopod-version: &cfg-isopod-version
     isopod_version: 0.29.6

--- a/src/examples/java_monorepo_workflows.yml
+++ b/src/examples/java_monorepo_workflows.yml
@@ -16,7 +16,7 @@ usage:
 
   orbs:
     compliance: ricardo/compliance-orb@2
-    ric-orb: ricardo/ric-orb@4
+    ric-orb: ricardo/ric-orb@5
 
   parameters:
     modified-common:
@@ -95,8 +95,8 @@ usage:
             # FIXME: replace value with your actual app path
             path: 'app1'
             <<: *cfg-cache-key-prefix
-            executor: maven_docker
-#            executor: maven_vm
+            executor: ric-orb/maven_docker
+#            executor: ric-orb/maven_vm
 
         - approve_deploy_dev:
             type: approval
@@ -173,8 +173,8 @@ usage:
             # FIXME: replace value with your actual app path
             path: 'app2'
             <<: *cfg-cache-key-prefix
-#            executor: maven_docker
-            executor: maven_vm
+#            executor: ric-orb/maven_docker
+            executor: ric-orb/maven_vm
 
         - approve_deploy_dev:
             type: approval

--- a/src/examples/java_singleapprepo.yml
+++ b/src/examples/java_singleapprepo.yml
@@ -15,7 +15,7 @@ usage:
 
   orbs:
     compliance: ricardo/compliance-orb@2
-    ric-orb: ricardo/ric-orb@4
+    ric-orb: ricardo/ric-orb@5
 
   cfg-isopod-version: &cfg-isopod-version
     isopod_version: 0.29.6
@@ -34,8 +34,8 @@ usage:
             name: 'maven-build-test'
             context: dev
             <<: *cfg-cache-key-prefix
-            executor: maven_docker
-#            executor: maven_vm
+            executor: ric-orb/maven_docker
+#            executor: ric-orb/maven_vm
 
         - approve_deploy_dev:
             type: approval

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -26,7 +26,10 @@ View the included _[hello.yml](./hello.yml)_ example.
 
 **Name**: maven_docker
 
-**Parameters**: none
+**Parameters**:
+
+- **tag** cimg/openjdk image version, default *11.0*
+
 
 A docker executor with java 11 installed (see also [Convenience Images: cimg/openjdk:11.0](https://circleci.com/developer/images/image/cimg/openjdk)). It is used for running java jobs in this orb.
 
@@ -36,7 +39,7 @@ A docker executor with java 11 installed (see also [Convenience Images: cimg/ope
 
 **Parameters**: none
 
-A vm executor with java 11 installed. It is used for running java jobs in this orb.
+A vm executor (ubuntu-2022:current) with java 11 installed. It is used for running java jobs in this orb.
 
 This executor is required in case a build depends on a running docker instance to execute testcontainers.
 

--- a/src/executors/maven_docker.yml
+++ b/src/executors/maven_docker.yml
@@ -1,8 +1,15 @@
 description: >
   Docker executor with JDK 11 to build java applications.
 
+parameters:
+  tag:
+    default: '11.0'
+    description: >
+      Pick a specific cimg/openjdk image version
+    type: string
+
 docker:
-  - image: 'cimg/openjdk:11.0'
+  - image: 'cimg/openjdk:<< parameters.tag >>'
     auth:
       username: $DOCKER_HUB_USERNAME
       password: $DOCKER_HUB_PASSWORD

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -362,7 +362,7 @@ jobs:
 **Parameters**:
 - **path**: Path of maven module for the app, or "." for single-app-repo. Default: "*.*"
 - **cache_key_prefix**: Prefix for the maven artifacts cache-key (used in combination with checksum of *pom.xml*). No caching if blank. Default: *blank* 
-- **executor**: Executor for the build. Values: *maven_docker*  (default; more lightweight), *maven_vm* (required by builds leveraging testcontainers and therefore depending on docker) 
+- **executor**: Executor for the build. Values: *ric-orb/maven_docker*  (default; more lightweight), *ric-orb/maven_vm* (required by builds leveraging testcontainers and therefore depending on docker) or your custom executor
 
 **Examples**
 
@@ -374,7 +374,7 @@ jobs:
   - ric-orb/maven_build_test:
       context: dev
       cache_key_prefix: "myrepo"
-      executor: maven_docker
+      executor: ric-orb/maven_docker
 ```
 Builds java sources using a VM builder
 ```yaml
@@ -384,7 +384,22 @@ jobs:
   - ric-orb/maven_build_test:
       context: dev
       cache_key_prefix: "myrepo"
-      executor: maven_vm
+      executor: ric-orb/maven_vm
+```
+Builds java sources using a custom executor
+```yaml
+# ...
+executors:
+  jdk17:
+    docker:
+      - image: cimg/openjdk:17.0.4
+# ...
+jobs:
+  # ...
+  - ric-orb/maven_build_test:
+      context: dev
+      cache_key_prefix: "myrepo"
+      executor: jdk17
 ```
 
 Builds java sources for a specific app from a monorepo
@@ -406,7 +421,7 @@ jobs:
 - **path**: Path of maven module for the app, or "." for single-app-repo. Default: "*.*"
 - **cache_key_prefix**: Prefix for the maven artifacts cache-key (used in combination with checksum of *pom_file*). No caching if blank. Default: *blank* 
 - **pom_file**: The pom file to be used for the maven build, the checksum used as part of the cache key is calculated from it. Default: "pom.xml"
-- **executor**: Executor for the build. Values: *maven_docker*  (default; more lightweight), *maven_vm* (required by builds leveraging testcontainers and therefore depending on docker) 
+- **executor**: Executor for the build. Values: *ric-orb/maven_docker*  (default; more lightweight), *ric-orb/maven_vm* (required by builds leveraging testcontainers and therefore depending on docker) or your custom executor
 
 **Examples**
 
@@ -418,7 +433,7 @@ jobs:
   - ric-orb/maven_deploy_artifact:
       context: dev
       cache_key_prefix: "myrepo"
-      executor: maven_docker
+      executor: ric-orb/maven_docker
 ```
 
 Deploy Java artifact using a VM builder
@@ -429,7 +444,23 @@ jobs:
   - ric-orb/maven_deploy_artifact:
       context: dev
       cache_key_prefix: "myrepo"
-      executor: maven_vm
+      executor: ric-orb/maven_vm
+```
+
+Deploy Java artifact using a custom executor
+```yaml
+# ...
+executors:
+  jdk17:
+    docker:
+      - image: cimg/openjdk:17.0.4
+# ...
+jobs:
+  # ...
+  - ric-orb/maven_deploy_artifact:
+      context: dev
+      cache_key_prefix: "myrepo"
+      executor: jdk17
 ```
 
 Deploy Java artifact for a specific module from a monorepo

--- a/src/jobs/maven_build_test.yml
+++ b/src/jobs/maven_build_test.yml
@@ -12,13 +12,11 @@ parameters:
     type: string
     default: ''
   executor:
-    description: 'Executor for the build (java_builder_docker is more lightweight, but some tests leveraging testcontainers etc require the java_builder_vm)'
-    type: enum
-    enum: [ 'maven_docker', 'maven_vm' ]
+    description: 'Executor for the build (Either use existing ones: maven_docker, maven_vm or define your own)'
+    type: executor
     default: 'maven_docker'
 
-executor:
-  name: << parameters.executor >>
+executor: << parameters.executor >>
 
 steps:
   - checkout

--- a/src/jobs/maven_deploy_artifact.yml
+++ b/src/jobs/maven_deploy_artifact.yml
@@ -16,13 +16,11 @@ parameters:
     type: string
     default: 'pom.xml'
   executor:
-    description: 'Executor for the build (java_builder_docker is more lightweight, but some tests leveraging testcontainers etc require the java_builder_vm)'
-    type: enum
-    enum: [ 'maven_docker', 'maven_vm' ]
+    description: 'Executor for the build (Either use existing ones: maven_docker, maven_vm or define your own)'
+    type: executor
     default: 'maven_docker'
 
-executor:
-  name: << parameters.executor >>
+executor: << parameters.executor >>
 
 steps:
   - checkout


### PR DESCRIPTION
Adapts the `maven_build_test` and `maven_deploy_artifact` to use the `executor` type instead of a string, allowing to use custom executors for building.