### PR TITLE
use circleCI's default docker version by default for remote-docker

### DIFF
--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -26,6 +26,26 @@ steps:
 #...
 ```
 
+### Setup Remote Docker
+
+**Name**: remote_docker
+
+This command wraps the built-in setup_remote_docker to make it work with optional version parameter.
+
+**Parameters**:
+- **docker_version**: [see docs](https://circleci.com/docs/2.0/building-docker-images/#docker-version). Default is *''* (which defaults to CircleCI's default)
+- **docker_layer_caching**: for enabling [docker layer caching](https://circleci.com/docs/2.0/docker-layer-caching/). Default is *true*
+
+Example:
+```yaml
+#...
+steps:
+  - ric-orb/remote_docker:
+      docker_version: '20.10.17'
+      docker_layer_caching: true
+#...
+```
+
 ### Docker build & push
 
 **Name**: docker_build_push

--- a/src/commands/remote_docker.yml
+++ b/src/commands/remote_docker.yml
@@ -1,0 +1,33 @@
+description: >
+  This command wraps the built-in setup_remote_docker to make it work with optional version parameter.
+
+parameters:
+  docker_version:
+    type: string
+    default: ''
+  docker_layer_caching:
+    type: boolean
+    default: true
+
+steps:
+  # pass the version if it was specified...
+  - when:
+      condition:
+        matches:
+          # check whether non-empty string
+          pattern: '.+'
+          value: << parameters.docker_version >>
+      steps:
+        - setup_remote_docker:
+            version: << parameters.docker_version >>
+            docker_layer_caching: << parameters.docker_layer_caching >>
+  # ... or use default version otherwise
+  - unless:
+      condition:
+        matches:
+          # check whether non-empty string
+          pattern: '.+'
+          value: << parameters.docker_version >>
+      steps:
+        - setup_remote_docker:
+            docker_layer_caching: << parameters.docker_layer_caching >>

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -88,8 +88,8 @@ jobs:
 - **private_hub_url**: JFrog url. Default is *$DOCKER_JFROG_REGISTRY_URL*
 - **private_hub_username**: JFrog credentials. Default is *$DOCKER_JFROG_USERNAME*
 - **private_hub_password**: JFrog credentials. Default is *$DOCKER_JFROG_PASSWORD*
-- **docker_version**: Default is *19.03.13*
-- **docker_layer_caching**: To enable docker layer caching. Default is *true*
+- **docker_version**: Default is *''* (which defaults to CircleCI's default)
+- **docker_layer_caching**: for enabling [docker layer caching](https://circleci.com/docs/2.0/docker-layer-caching/). Default is *true*
 
 This job builds and pushes Docker image to private Docker hub. It uses docker for building and pushing.
 
@@ -133,8 +133,8 @@ jobs:
 - **cache_name**: Not required. If not specified cache will not be used/created
 - **maven_credentials**: environment/context variable name (just the name, not the actual variable!) which holds base64 encoded content for .m2/settings.xml file. Default is *ARTIFACTORY_MAVEN_CREDENTIALS* which already defined in our contexts
 - **npm_credentials**: environment/context variable name (just the name, not the actual variable!) which holds base64 encoded content for .npmrc file. Default is *NPM_RC* which already defined in our contexts
+- **docker_version**: [see docs](https://circleci.com/docs/2.0/building-docker-images/#docker-version). Default is *''* (which defaults to CircleCI's default)
 - **docker_layer_caching**: for enabling [docker layer caching](https://circleci.com/docs/2.0/docker-layer-caching/). Default is *true*
-- **docker_version**: [see docs](https://circleci.com/docs/2.0/building-docker-images/#docker-version). Default is *19.03.13*
 - **prebuild_steps**: the list of steps that are executed to prepare building image/application. Default is none
 - **postbuild_steps**: the list of steps that are executed after building image/application. Default is none
 
@@ -178,8 +178,9 @@ Example with custom properties:
 jobs:
   # ...
   - ric-orb/build_push_image:
+      context: dev
       isopod_version: "0.29.6"
-      docker_version: "19.03.13"
+      docker_version: "20.10.17"
       isopod_config: isopod.yaml
       private_hub_username: ${PDOCKER_USERNAME}
       private_hub_password: ${PDOCKER_PASSWORD}
@@ -187,7 +188,6 @@ jobs:
       docker_hub_password: ${MY_DOCKER_HUB_PASSWORD}
       private_hub_url: ${PDOCKER_REGISTRY_URL}
       cache_name: dependency-cache-{{ checksum "go.sum" }}
-      context: dev
       requires:
         - maven_build_test
 ```
@@ -200,8 +200,8 @@ jobs:
   - ric-orb/build_push_image:
       context: dev
       path: "myapp"
-      docker_version: "19.03.13"
       isopod_version: "0.29.6"
+      docker_version: "20.10.17"
       requires:
         - maven_build_test
 ```

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -52,7 +52,7 @@ parameters:
     default: true
   docker_version:
     type: string
-    default: '19.03.13'
+    default: ''
   prebuild_steps:
     description: 'Steps that will run before build'
     type: steps
@@ -70,9 +70,9 @@ steps:
   # only really needed for npm/node, but less painful to just do it than to configure it in each node build config
   - npm_auth:
       npm_credentials: << parameters.npm_credentials >>
-  - setup_remote_docker:
+  - remote_docker:
+      docker_version: << parameters.docker_version >>
       docker_layer_caching: << parameters.docker_layer_caching >>
-      version: << parameters.docker_version >>
   - login_docker_registry:
       username: <<parameters.docker_hub_username>>
       password: <<parameters.docker_hub_password>>

--- a/src/jobs/docker_build_push.yml
+++ b/src/jobs/docker_build_push.yml
@@ -33,7 +33,7 @@ parameters:
     default: $DOCKER_JFROG_REGISTRY_URL
   docker_version:
     type: string
-    default: '19.03.13'
+    default: ''
   docker_layer_caching:
     type: boolean
     default: true
@@ -42,8 +42,8 @@ steps:
   - checkout
   - attach_workspace:
       at: .
-  - setup_remote_docker:
-      version: << parameters.docker_version >>
+  - remote_docker:
+      docker_version: << parameters.docker_version >>
       docker_layer_caching: << parameters.docker_layer_caching >>
   - login_docker_registry:
       username: <<parameters.docker_hub_username>>


### PR DESCRIPTION
see [slack#this-thread](https://generalmarketplaces.slack.com/archives/C045RL4D25V/p1665994055865799)
and [slack#other-thread](https://generalmarketplaces.slack.com/archives/C043LTSQ535/p1665735292744169)

stop overwriting docker version for remote docker with something that is not always supported anymore by circleCI