### PR TITLE
Introduce CodeQL

### DIFF
--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -566,6 +566,58 @@ jobs:
       context: dev
 ```
 
+### CodeQL
+
+**Name**: codeql
+
+**Parameters**:
+
+- **executor**: [CircleCI Executor](https://circleci.com/docs/2.0/configuration-reference/#docker--machine--macos--windows-executor) to execute CodeQL. As the code to be analyzed also needs to be built, ensure using an executor that is capable of building the code
+- **language**: Specify the identifier for the language to create a database for, one of: `cpp`, `csharp`, `go`, `java`, `javascript`, `python`, and `ruby` (use `javascript` to analyze `TypeScript` code). See [Supported languages and frameworks](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/)
+- **pre-init-steps**: Steps to execute prior to creating the database. This is usually used to restore a cache of dependencies used when building
+- **build-command**: Use to specify the build command or script that invokes the build process for the codebase. If absent, tries to automatically build. Not needed for Python and JavaScript/TypeScript analysis
+
+**Examples**
+
+This example uses auto compile functionality to build the code
+```yaml
+jobs:
+  - ric-orb/codeql:
+      context: dev
+      executor: jdk17
+      language: java
+      pre-init-steps: 
+        - ric-orb/maven_restore_artifacts:
+            prefix: foo
+            path: path-to-directory
+```
+
+This example shows an example for Go
+```yaml
+jobs:
+  - ric-orb/codeql:
+      context: dev
+      executor:
+        name: go/default
+        tag: '1.17'
+      language: go
+      build-command: 'make install && make build'
+      pre-init-steps: 
+        - restore_cache:
+            keys:
+              - 'go-mod-{{ arch }}-{{ checksum foo/go.sum"  }}'
+              - 'go-mod-{{ arch }}-'
+```
+
+This example shows an example for javascript, where also a build of the code is not necessary
+```yaml
+jobs:
+  - ric-orb/codeql:
+      context: dev
+      executor: js
+      language: javascript
+```
+
 ## See:
  - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)
  - [How To Author Commands](https://circleci.com/docs/2.0/reusing-config/#authoring-parameterized-jobs)

--- a/src/jobs/codeql.yml
+++ b/src/jobs/codeql.yml
@@ -1,0 +1,60 @@
+description: >
+  Code scanning is a feature that you use to analyze the code in a GitHub repository to find security vulnerabilities and coding errors. Any problems identified by the analysis are shown in GitHub. For information, see https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql
+
+parameters:
+  executor:
+    description: 'Executor to execute CodeQL. As the code to be analyzed also needs to be built, ensure using an executor that is capable of building the code'
+    type: executor
+  language:
+    description: 'Specify the identifier for the language to create a database for, one of: cpp`, `csharp`, `go`, `java`, `javascript`, `python`, and `ruby (use javascript to analyze TypeScript code). See https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/'
+    type: string
+  pre-init-steps:
+    description: 'Steps to execute prior to creating the database. This is usually used to restore a cache of dependencies used when building'
+    type: steps
+    default: [ ]
+  build-command:
+    description: 'Use to specify the build command or script that invokes the build process for the codebase. If absent, tries to automatically build. Not needed for Python and JavaScript/TypeScript analysis'
+    type: string
+    default: ''
+
+executor: << parameters.executor >>
+
+steps:
+  - checkout
+  - run:
+      name: Setting up CodeQL
+      working_directory: ~/
+      command: |
+        wget https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz && \
+        tar -xzf ./codeql-bundle-linux64.tar.gz && \
+        ln -s ~/codeql/codeql ~/bin/codeql
+  - steps: << parameters.pre-init-steps >>
+  - run:
+      name: Creating CodeQL databases to analyze
+      working_directory: ~/
+      command: |
+        cmd=(codeql database create << parameters.language >>-codeql-db)
+
+        cmd+=(--language << parameters.language >>)
+        cmd+=(--source-root ~/project)
+        cmd+=(--no-run-unnecessary-builds)
+
+        if [[ ! -z "<< parameters.build-command >>" ]]; then
+          cmd+=(--command '<< parameters.build-command >>')
+        fi
+
+        "${cmd[@]}"
+  - run:
+      name: Analyzing CodeQL database
+      working_directory: ~/
+      command: |
+        codeql database analyze << parameters.language >>-codeql-db << parameters.language >>-security-and-quality.qls \
+          --format sarif-latest \
+          --output=<< parameters.language >>-codeql-report.sarif
+  - run:
+      name: Uploading results to GitHub
+      working_directory: ~/
+      command: |
+        echo $GITHUB_CODEQL_TOKEN | codeql github upload-results --repository=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
+          --ref=refs/heads/$CIRCLE_BRANCH --commit=$CIRCLE_SHA1 --sarif=<< parameters.language >>-codeql-report.sarif \
+          --github-auth-stdin


### PR DESCRIPTION
This change introduces the `codeql` job that eventually will be used by all of our repositories that are deployed on production. 

The reason to have CodeQL as part of CircleCI instead of using GitHub Actions is to lower the risk of stuck builds / deployments because one of the CI platforms (CircleCI or GitHub) is down.

This new CircleCI job was created according to the CodeQL documentation from GitHub: https://docs.github.com/en/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system. It is supposed to support all the repositories, and therefore tech stacks, we currently have and use. 