### PR TITLE
login to docker registry for go-build-test

### DIFF
--- a/src/jobs/go_build_test.yml
+++ b/src/jobs/go_build_test.yml
@@ -21,6 +21,10 @@ executor: << parameters.executor >>
 
 steps:
   - checkout
+  - login_docker_registry:
+      url: ${DOCKER_JFROG_REGISTRY_URL}
+      username: ${DOCKER_JFROG_USERNAME}
+      password: ${DOCKER_JFROG_PASSWORD}
   - restore_cache:
       keys:
         - 'go-mod-{{ arch }}-{{ checksum "<< parameters.work_dir >>/go.sum"  }}'


### PR DESCRIPTION
this allows a build to use dockercompose/testcontainers if it wanted to do so