### PR TITLE
Fix folder for maven cache

### DIFF
--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -399,3 +399,4 @@ steps:
 
 - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)
 - [How to author commands](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands)
+

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -399,4 +399,3 @@ steps:
 
 - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)
 - [How to author commands](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands)
-

--- a/src/commands/maven_cache_artifacts.yml
+++ b/src/commands/maven_cache_artifacts.yml
@@ -18,5 +18,5 @@ parameters:
 steps:
   - save_cache:
       paths:
-        - ~/.m2
+        - ~/.m2/repository
       key: << parameters.prefix >>-{{ checksum "<< parameters.pom_file >>" }}-<< parameters.path >>

--- a/src/jobs/maven_build_test.yml
+++ b/src/jobs/maven_build_test.yml
@@ -20,10 +20,10 @@ executor: << parameters.executor >>
 
 steps:
   - checkout
-  - maven_auth
   - maven_restore_artifacts:
       prefix: << parameters.cache_key_prefix >>
       path: << parameters.path >>
+  - maven_auth
   - login_docker_registry:
       url: ${DOCKER_JFROG_REGISTRY_URL}
       username: ${DOCKER_JFROG_USERNAME}

--- a/src/jobs/maven_deploy_artifact.yml
+++ b/src/jobs/maven_deploy_artifact.yml
@@ -24,11 +24,11 @@ executor: << parameters.executor >>
 
 steps:
   - checkout
-  - maven_auth
   - maven_restore_artifacts:
       prefix: << parameters.cache_key_prefix >>
       pom_file: << parameters.pom_file >>
       path: << parameters.path >>
+  - maven_auth
   - maven_deploy_artifact:
       path: << parameters.path >>
       pom_file: << parameters.pom_file >>


### PR DESCRIPTION
- We should only cache `.m2/repository` so that the settings.xml is not cache as it also contained the password.
- The cache restore was always overwriting the settings.xml, and therefore we changed the order (first restore cache, then load settings.xml from CircleCI env var), to support older caches that still contain settings.xml.