### PR TITLE
add support for google artifact registry

### DIFF
--- a/src/commands/docker_build_push.yml
+++ b/src/commands/docker_build_push.yml
@@ -11,7 +11,14 @@ parameters:
 steps:
   - run:
       name: 'docker build'
-      command: docker build -t ric-docker.jfrog.io/ricardo-ch/<< parameters.image_name >>:${CIRCLE_BRANCH}-${CIRCLE_SHA1} .
+      command: docker build .
+  - run:
+      name: 'docker tag'
+      command: |
+        [[ ${JFROG_ENABLED} == "true" ]] && docker tag ric-docker.jfrog.io/ricardo-ch/<< parameters.image_name >>:${CIRCLE_BRANCH}-${CIRCLE_SHA1}
+        [[ ${GAR_ENABLED} == "true" ]] && docker tag europe-west1-docker.pkg.dev/ricardo-platform/docker/<< parameters.image_name >>:${CIRCLE_BRANCH}-${CIRCLE_SHA1}
   - run:
       name: 'docker push'
-      command: docker push ric-docker.jfrog.io/ricardo-ch/<< parameters.image_name >>:${CIRCLE_BRANCH}-${CIRCLE_SHA1}
+      command: |
+        [[ ${JFROG_ENABLED} == "true" ]] && docker push ric-docker.jfrog.io/ricardo-ch/<< parameters.image_name >>:${CIRCLE_BRANCH}-${CIRCLE_SHA1}
+        [[ ${GAR_ENABLED} == "true" ]] && docker push europe-west1-docker.pkg.dev/ricardo-platform/docker/<< parameters.image_name >>:${CIRCLE_BRANCH}-${CIRCLE_SHA1}

--- a/src/executors/isopod.yml
+++ b/src/executors/isopod.yml
@@ -4,7 +4,7 @@ docker:
   - image: 'europe-west1-docker.pkg.dev/ricardo-platform/docker/isopod:<<parameters.tag>>'
     auth:
       username: _json_key
-      password: ${GOOGLE_APPLICATION_CREDENTIALS}
+      password: ${GAR_APPLICATION_CREDENTIALS}
 parameters:
   tag:
     default: ${ISOPOD_VERSION}

--- a/src/executors/isopod.yml
+++ b/src/executors/isopod.yml
@@ -1,21 +1,13 @@
 description: >
   Isopod executor
 docker:
-  - image: 'ric-docker.jfrog.io/ricardo-ch/isopod:<<parameters.tag>>'
+  - image: 'europe-west1-docker.pkg.dev/ricardo-platform/docker/isopod:<<parameters.tag>>'
     auth:
-      username: <<parameters.username>>
-      password: <<parameters.password>>
+      username: _json_key
+      password: ${GOOGLE_APPLICATION_CREDENTIALS}
 parameters:
   tag:
     default: ${ISOPOD_VERSION}
     description: >
       Pick a specific ricardo-ch/isopod image variant.
     type: string
-  username:
-    type: string
-    description: >
-      Artifactory username.
-  password:
-    type: string
-    description: >
-      Artifactory password.

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -6,8 +6,6 @@ description: >
 executor:
   name: isopod
   tag: <<parameters.isopod_version>>
-  username: <<parameters.private_hub_username>>
-  password: <<parameters.private_hub_password>>
 
 parameters:
   path:
@@ -27,15 +25,6 @@ parameters:
   docker_hub_password:
     type: string
     default: $DOCKER_HUB_PASSWORD
-  private_hub_username:
-    type: string
-    default: $DOCKER_JFROG_USERNAME
-  private_hub_password:
-    type: string
-    default: $DOCKER_JFROG_PASSWORD
-  private_hub_url:
-    type: string
-    default: $DOCKER_JFROG_REGISTRY_URL
   gar_username:
     type: string
     default: $DOCKER_GAR_USERNAME

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -25,6 +25,15 @@ parameters:
   docker_hub_password:
     type: string
     default: $DOCKER_HUB_PASSWORD
+  private_hub_username:
+    type: string
+    default: $DOCKER_JFROG_USERNAME
+  private_hub_password:
+    type: string
+    default: $DOCKER_JFROG_PASSWORD
+  private_hub_url:
+    type: string
+    default: $DOCKER_JFROG_REGISTRY_URL
   gar_username:
     type: string
     default: $DOCKER_GAR_USERNAME

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -36,6 +36,15 @@ parameters:
   private_hub_url:
     type: string
     default: $DOCKER_JFROG_REGISTRY_URL
+  gar_username:
+    type: string
+    default: $DOCKER_GAR_USERNAME
+  gar_password:
+    type: string
+    default: $DOCKER_GAR_PASSWORD
+  gar_url:
+    type: string
+    default: $DOCKER_GAR_REGISTRY_URL
   cache_name:
     type: string
     default: ''
@@ -80,6 +89,10 @@ steps:
       url: <<parameters.private_hub_url>>
       username: <<parameters.private_hub_username>>
       password: <<parameters.private_hub_password>>
+  - login_docker_registry:
+      url: <<parameters.gar_url>>
+      username: <<parameters.gar_username>>
+      password: <<parameters.gar_password>>
   - when:
       condition: <<parameters.cache_name>>
       steps:

--- a/src/jobs/deploy_job.yml
+++ b/src/jobs/deploy_job.yml
@@ -5,8 +5,6 @@ description: >
 executor:
   name: isopod
   tag: <<parameters.isopod_version>>
-  username: <<parameters.private_hub_username>>
-  password: <<parameters.private_hub_password>>
 
 parameters:
   path:

--- a/src/jobs/docker_build_push.yml
+++ b/src/jobs/docker_build_push.yml
@@ -31,6 +31,15 @@ parameters:
   private_hub_url:
     type: string
     default: $DOCKER_JFROG_REGISTRY_URL
+  gar_username:
+    type: string
+    default: $DOCKER_GAR_USERNAME
+  gar_password:
+    type: string
+    default: $DOCKER_GAR_PASSWORD
+  gar_url:
+    type: string
+    default: $DOCKER_GAR_REGISTRY_URL
   docker_version:
     type: string
     default: ''
@@ -52,6 +61,10 @@ steps:
       url: <<parameters.private_hub_url>>
       username: <<parameters.private_hub_username>>
       password: <<parameters.private_hub_password>>
+  - login_docker_registry:
+      url: <<parameters.gar_url>>
+      username: <<parameters.gar_username>>
+      password: <<parameters.gar_password>>
   - attach_workspace:
       at: .
   - docker_build_push:

--- a/src/jobs/docker_build_push.yml
+++ b/src/jobs/docker_build_push.yml
@@ -5,8 +5,6 @@ description: >
 executor:
   name: isopod
   tag: $ISOPOD_VERSION
-  username: <<parameters.private_hub_username>>
-  password: <<parameters.private_hub_password>>
 
 parameters:
   image_name:
@@ -22,15 +20,6 @@ parameters:
   docker_hub_password:
     type: string
     default: $DOCKER_HUB_PASSWORD
-  private_hub_username:
-    type: string
-    default: $DOCKER_JFROG_USERNAME
-  private_hub_password:
-    type: string
-    default: $DOCKER_JFROG_PASSWORD
-  private_hub_url:
-    type: string
-    default: $DOCKER_JFROG_REGISTRY_URL
   gar_username:
     type: string
     default: $DOCKER_GAR_USERNAME

--- a/src/jobs/docker_build_push.yml
+++ b/src/jobs/docker_build_push.yml
@@ -20,6 +20,15 @@ parameters:
   docker_hub_password:
     type: string
     default: $DOCKER_HUB_PASSWORD
+  private_hub_username:
+    type: string
+    default: $DOCKER_JFROG_USERNAME
+  private_hub_password:
+    type: string
+    default: $DOCKER_JFROG_PASSWORD
+  private_hub_url:
+    type: string
+    default: $DOCKER_JFROG_REGISTRY_URL
   gar_username:
     type: string
     default: $DOCKER_GAR_USERNAME

--- a/src/jobs/go_build_test.yml
+++ b/src/jobs/go_build_test.yml
@@ -26,7 +26,7 @@ steps:
       username: ${DOCKER_JFROG_USERNAME}
       password: ${DOCKER_JFROG_PASSWORD}
   - login_docker_registry:
-      url: <<DOCKER_GAR_REGISTRY_URL>>
+      url: ${DOCKER_GAR_REGISTRY_URL}
       username: ${DOCKER_GAR_USERNAME}
       password: ${DOCKER_GAR_PASSWORD}
   - restore_cache:

--- a/src/jobs/go_build_test.yml
+++ b/src/jobs/go_build_test.yml
@@ -25,6 +25,10 @@ steps:
       url: ${DOCKER_JFROG_REGISTRY_URL}
       username: ${DOCKER_JFROG_USERNAME}
       password: ${DOCKER_JFROG_PASSWORD}
+  - login_docker_registry:
+      url: <<DOCKER_GAR_REGISTRY_URL>>
+      username: ${DOCKER_GAR_USERNAME}
+      password: ${DOCKER_GAR_PASSWORD}
   - restore_cache:
       keys:
         - 'go-mod-{{ arch }}-{{ checksum "<< parameters.work_dir >>/go.sum"  }}'

--- a/src/jobs/maven_build_test.yml
+++ b/src/jobs/maven_build_test.yml
@@ -28,6 +28,10 @@ steps:
       url: ${DOCKER_JFROG_REGISTRY_URL}
       username: ${DOCKER_JFROG_USERNAME}
       password: ${DOCKER_JFROG_PASSWORD}
+  - login_docker_registry:
+      url: <<DOCKER_GAR_REGISTRY_URL>>
+      username: ${DOCKER_GAR_USERNAME}
+      password: ${DOCKER_GAR_PASSWORD}
   - maven_build_test:
       path: << parameters.path >>
   - maven_cache_artifacts:

--- a/src/jobs/maven_build_test.yml
+++ b/src/jobs/maven_build_test.yml
@@ -15,16 +15,7 @@ parameters:
     description: 'Executor for the build (Either use existing ones: maven_docker, maven_vm or define your own)'
     type: executor
     default: 'maven_docker'
-  gar_username:
-    type: string
-    default: $DOCKER_GAR_USERNAME
-  gar_password:
-    type: string
-    default: $DOCKER_GAR_PASSWORD
-  gar_url:
-    type: string
-    default: $DOCKER_GAR_REGISTRY_URL
-    
+
 executor: << parameters.executor >>
 
 steps:
@@ -38,7 +29,7 @@ steps:
       username: ${DOCKER_JFROG_USERNAME}
       password: ${DOCKER_JFROG_PASSWORD}
   - login_docker_registry:
-      url: <<DOCKER_GAR_REGISTRY_URL>>
+      url: ${DOCKER_GAR_REGISTRY_URL}
       username: ${DOCKER_GAR_USERNAME}
       password: ${DOCKER_GAR_PASSWORD}
   - maven_build_test:

--- a/src/jobs/maven_build_test.yml
+++ b/src/jobs/maven_build_test.yml
@@ -15,7 +15,16 @@ parameters:
     description: 'Executor for the build (Either use existing ones: maven_docker, maven_vm or define your own)'
     type: executor
     default: 'maven_docker'
-
+  gar_username:
+    type: string
+    default: $DOCKER_GAR_USERNAME
+  gar_password:
+    type: string
+    default: $DOCKER_GAR_PASSWORD
+  gar_url:
+    type: string
+    default: $DOCKER_GAR_REGISTRY_URL
+    
 executor: << parameters.executor >>
 
 steps:

--- a/src/jobs/push_build_to_bucket_job.yml
+++ b/src/jobs/push_build_to_bucket_job.yml
@@ -4,8 +4,7 @@ description: >
 executor:
   name: isopod
   tag: <<parameters.isopod_version>>
-  username: <<parameters.private_hub_username>>
-  password: <<parameters.private_hub_password>>
+
 parameters:
   isopod_version:
     type: string


### PR DESCRIPTION
these changes require the following environment variables in the context:
- GAR_APPLICATION_CREDENTIALS: [see 1password](https://start.1password.com/open/i?a=MSNVIFFLNRGSHOM4JGHI76MG6Y&v=cuv5v6wmn362r7i7lr2huklpre&i=2pgccgovd5dpjewpjsp7ddai5q&h=ricardo-ch.1password.com)
- DOCKER_GAR_REGISTRY_URL: `europe-west1-docker.pkg.dev`
- DOCKER_GAR_USERNAME: `_json_key_base64`
- DOCKER_GAR_PASSWORD: `<base64 encoded json key from above>`
- JFROG_ENABLED: `true`
- GAR_ENABLED: `true`

Once we've migrated we can simply remove the JFROG_ENABLED variable from the context to disable pushing to jfrog.