### PR TITLE
Use Virtual Repository in us-east4

### DIFF
--- a/src/executors/isopod.yml
+++ b/src/executors/isopod.yml
@@ -1,7 +1,7 @@
 description: >
   Isopod executor
 docker:
-  - image: 'us-east4-docker.pkg.dev/ricardo-platform/docker-cicd-virtual/isopod:<<parameters.tag>>'
+  - image: 'us-east4-docker.pkg.dev/ricardo-platform/docker-virtual-cicd/isopod:<<parameters.tag>>'
     auth:
       username: _json_key
       password: ${GAR_APPLICATION_CREDENTIALS}

--- a/src/executors/isopod.yml
+++ b/src/executors/isopod.yml
@@ -1,7 +1,7 @@
 description: >
   Isopod executor
 docker:
-  - image: 'europe-west1-docker.pkg.dev/ricardo-platform/docker/isopod:<<parameters.tag>>'
+  - image: 'us-east4-docker.pkg.dev/ricardo-platform/docker-cicd-virtual/isopod:<<parameters.tag>>'
     auth:
       username: _json_key
       password: ${GAR_APPLICATION_CREDENTIALS}


### PR DESCRIPTION
Use the virtual docker repository in us-east4 to reduce intercontinental egress costs (circleci is running everything in Northern Virgina).
This repository only contains isopod and platform-charts-deploy (the most used images in circleci)