### PR TITLE
set default value for GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/src/scripts/authenticate.sh
+++ b/src/scripts/authenticate.sh
@@ -1,5 +1,6 @@
 # Authenticate to GCP. All needed values have to be already present in CircleCi context or environment.
 echo "${GCLOUD_SERVICE_KEY}" > "${HOME}"/gcp-key.json
+export GOOGLE_APPLICATION_CREDENTIALS="${HOME}"/gcp-key.json
 gcloud auth activate-service-account --key-file "${HOME}"/gcp-key.json
 gcloud --quiet config set project "${GOOGLE_PROJECT_ID}"
 gcloud --quiet config set compute/zone "${GKE_COMPUTE_ZONE}"


### PR DESCRIPTION
GOOGLE_APPLICATION_CREDENTIALS is required to create a new KMS client 