### PR TITLE
Add default Dockerfiles by language

### DIFF
--- a/src/commands/docker_fetch_dockerfile.yml
+++ b/src/commands/docker_fetch_dockerfile.yml
@@ -5,6 +5,10 @@ parameters:
   work_dir:
     type: string
     default: .
+  repository_version:
+    description: 'The version of the ricardo-orbs from which to get the Dockerfiles, it can be a tag or a branch.'
+    type: string
+    default: 'main'
   docker_template:
     description: 'Get the Dockerfile from a template, normally for a given language/version.'
     type: enum
@@ -16,12 +20,13 @@ steps:
       name: Ensure or fetch Dockerfile
       working_directory: << parameters.work_dir >>
       environment:
+        REPOSITORY_ROOT: https://raw.githubusercontent.com/ricardo-ch/ricardo-orbs/<< parameters.repository_version >>
         DOCKER_TEMPLATE: << parameters.docker_template >>
       command: |
         if [[ -f "./Dockerfile" ]]; then
           echo "Dockerfile already exists, skipping"
         elif [[ "$DOCKER_TEMPLATE" != "none" ]]; then
-          TEMPLATE_URL="https://raw.githubusercontent.com/ricardo-ch/ricardo-orbs/main/src/templates/docker/$DOCKER_TEMPLATE/Dockerfile"
+          TEMPLATE_URL="$REPOSITORY_ROOT/src/templates/docker/$DOCKER_TEMPLATE/Dockerfile"
           echo "Fetching Dockerfile for $DOCKER_TEMPLATE from $TEMPLATE_URL ..."
           wget -O ./Dockerfile "$TEMPLATE_URL"
         else

--- a/src/commands/docker_fetch_dockerfile.yml
+++ b/src/commands/docker_fetch_dockerfile.yml
@@ -1,0 +1,30 @@
+description: >
+  Ensures that the dockerfile is present, if not, download one for the selected template.
+
+parameters:
+  work_dir:
+    type: string
+    default: .
+  docker_template:
+    description: 'Get the Dockerfile from a template, normally for a given language/version.'
+    type: enum
+    enum: ['none', 'java17']
+    default: 'none'
+
+steps:
+  - run:
+      name: Ensure or fetch Dockerfile
+      working_directory: << parameters.work_dir >>
+      environment:
+        DOCKER_TEMPLATE: << parameters.docker_template >>
+      command: |
+        if [[ -f "./Dockerfile" ]]; then
+          echo "Dockerfile already exists, skipping"
+        elif [[ "$DOCKER_TEMPLATE" != "none" ]]; then
+          TEMPLATE_URL="https://raw.githubusercontent.com/ricardo-ch/ricardo-orbs/main/src/templates/docker/$DOCKER_TEMPLATE/Dockerfile"
+          echo "Fetching Dockerfile for $DOCKER_TEMPLATE from $TEMPLATE_URL ..."
+          wget -O ./Dockerfile "$TEMPLATE_URL"
+        else
+          echo "Neither a Dockerfile exists nor a template was selected, failing."
+          exit 1
+        fi

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -73,6 +73,11 @@ parameters:
   image_suffix:
     type: string
     default: ""
+  docker_template:
+    description: 'Get the Dockerfile from a template, normally for a given language/version.'
+    type: enum
+    enum: ['none', 'java17']
+    default: 'none'
 
 steps:
   - checkout
@@ -105,6 +110,9 @@ steps:
   - attach_workspace:
       at: .
   - steps: << parameters.prebuild_steps >>
+  - docker_fetch_dockerfile:
+      work_dir: << parameters.path >>
+      docker_template: << parameters.docker_template >>
   - build_push:
       work_dir: << parameters.path >>
       config: << parameters.isopod_config >>

--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -73,6 +73,10 @@ parameters:
   image_suffix:
     type: string
     default: ""
+  repository_version:
+    description: 'The version of the ricardo-orbs from which to get the Dockerfiles, it can be a tag or a branch.'
+    type: string
+    default: 'v7.6.0'
   docker_template:
     description: 'Get the Dockerfile from a template, normally for a given language/version.'
     type: enum
@@ -112,6 +116,7 @@ steps:
   - steps: << parameters.prebuild_steps >>
   - docker_fetch_dockerfile:
       work_dir: << parameters.path >>
+      repository_version: << parameters.repository_version >>
       docker_template: << parameters.docker_template >>
   - build_push:
       work_dir: << parameters.path >>

--- a/src/templates/docker/java17/Dockerfile
+++ b/src/templates/docker/java17/Dockerfile
@@ -1,0 +1,42 @@
+# base image to build a JRE
+FROM amazoncorretto:17.0.7 as corretto-jdk
+
+# required for strip-debug to work and unzipping the jar
+RUN yum install -y binutils unzip
+
+# Identify modules
+COPY target/*.jar app.jar
+RUN unzip -d unpacked app.jar && \
+    $JAVA_HOME/bin/jdeps \
+    --ignore-missing-deps \
+    --print-module-deps \
+    -q \
+    --recursive \
+    --multi-release 17 \
+    --class-path="/unpacked/BOOT-INF/lib/*" \
+    --module-path="/unpacked/BOOT-INF/lib/*" \
+    ./app.jar > /modules.info
+
+# Build small JRE image
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules $(cat /modules.info) \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+FROM ubuntu:22.04
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# copy JRE from the base image
+COPY --from=corretto-jdk /jre $JAVA_HOME
+
+# Non-root user
+USER 1984:1984
+
+COPY --chown=1984:1984 target/*.jar app.jar
+
+ENTRYPOINT ["java","-XX:MaxRAMPercentage=75.0","-Djava.security.egd=file:/dev/urandom","-jar","/app.jar"]

--- a/src/templates/docker/java17/Dockerfile
+++ b/src/templates/docker/java17/Dockerfile
@@ -1,5 +1,5 @@
 # base image to build a JRE
-FROM amazoncorretto:17.0.7 as corretto-jdk
+FROM amazoncorretto:17 as corretto-jdk
 
 # required for strip-debug to work and unzipping the jar
 RUN yum install -y binutils unzip


### PR DESCRIPTION
With this addition, we can have "templates" of Dockerfiles for different languages, that will be fetched and used by CircleCI so they don't need to be present in the apps' repositories.
This makes sense because in 99% of the cases all our apps are using a fixed Dockerfile that we just copy around. So this should ease the rollout of newer versions of the Dockerfile.
Of course, it is still possible to provide a `Dockerfile` in the original app repo, if one exists that one will be used.
The templates are expected to be in the directory `src/templates/docker/{docker_template}`. So far I am adding only one for `java17`, more (for Go, TS, Python, etc.) can be added later.
