### PR TITLE
use gcp public image in js push-to-bucket job

### DIFF
--- a/src/jobs/js_push_build_to_bucket_job.yml
+++ b/src/jobs/js_push_build_to_bucket_job.yml
@@ -2,13 +2,8 @@ description: >
   This job sync ui assets with web assets to google storage bucket.
   Authentication is needed for creating/deleting storage objects.
 
-# Executor
-
-executor:
-  name: isopod
-  tag: <<parameters.isopod_version>>
-  username: <<parameters.private_hub_username>>
-  password: <<parameters.private_hub_password>>
+docker:
+  - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
 
 steps:
   - attach_workspace:
@@ -25,9 +20,6 @@ steps:
 # Parameters
 
 parameters:
-  isopod_version:
-    type: string
-    default: ${ISOPOD_VERSION}
   private_hub_username:
     type: string
     default: $DOCKER_JFROG_USERNAME


### PR DESCRIPTION
stop using isopod executor in [src/jobs/js_push_build_to_bucket_job.yml](https://github.com/ricardo-ch/ricardo-orbs/pull/91/files#diff-2b0e22a058e164d0fb92b99feb62d1e1f32ce194bd7d3fa566ce66adf260dad9)
[slack](https://generalmarketplaces.slack.com/archives/C043LTSQ535/p1687339764349499)
[working execution](https://app.circleci.com/pipelines/github/ricardo-ch/marketplace-frontend-app/4484/workflows/55d3138f-2db0-43e8-b215-4d760a6a9d62/jobs/20609)