### PR TITLE
Fix maven_assert_snapshot_version executor

### DIFF
--- a/src/jobs/maven_assert_snapshot_version.yml
+++ b/src/jobs/maven_assert_snapshot_version.yml
@@ -7,9 +7,12 @@ parameters:
     description: 'The pom file to use'
     type: string
     default: 'pom.xml'
+  executor:
+    description: 'Executor for the build (Either use existing ones: maven_docker, maven_vm or define your own)'
+    type: executor
+    default: 'maven_docker'
 
-executor:
-  name: 'maven_docker'
+executor: << parameters.executor >>
 
 steps:
   - checkout

--- a/src/jobs/maven_assert_snapshot_version.yml
+++ b/src/jobs/maven_assert_snapshot_version.yml
@@ -16,6 +16,7 @@ executor: << parameters.executor >>
 
 steps:
   - checkout
+  - maven_auth
   - maven_assert_expression:
       expression: 'project.version'
       pattern: '^.*-SNAPSHOT$'


### PR DESCRIPTION
It should support providing the executor (for example for Java 17)