### PR TITLE
npm publish from build folder

### DIFF
--- a/src/jobs/js_publish_npm_module_job.yml
+++ b/src/jobs/js_publish_npm_module_job.yml
@@ -55,7 +55,7 @@ steps:
               git config --global user.email `git log -1 --pretty=format:'%ae'`
         - run:
             name: Github Registry authentication
-            # NPM_GHP_TOKEN was generated for ricardo-saas user
+            # NPM_GHP_TOKEN was generated for ricardo-circleci user
             command: |
               npm set registry https://npm.pkg.github.com/
               echo "//npm.pkg.github.com/:_authToken=$NPM_GHP_TOKEN" > ~/.npmrc
@@ -68,6 +68,14 @@ steps:
               else
                 echo "Publishing $VERSION_VAR version"
                 npm version $VERSION_VAR
+
+                # ci:prepublish need to copy at least package.json file into build folder
+                # ideally packages.json should be formatted to have only necessary information, e.g. excluding devDependencies
+                yarn ci:prepublish
+
+                # we will publish from ./build folder
+                cd build
+
                 npm publish
               fi
         - run:


### PR DESCRIPTION
Change the way how we publish npm modules.

Now `js_publish_npm_module_job` requires` ci:prepublish` script to exist in package.json `scripts`.
This script need to copy `package.json` into build folder and ideally format it to have only publish essential information, for example we don't want to have devDependencies listed in published `package.json` file.

Good news is that with this PR we won't need to use `/build` as part of the path when importing some nested components

Proof that it works:
[style-guide-react PR](https://github.com/ricardo-ch/style-guide-react/pull/1409) and [marketplace-spa PR](https://github.com/ricardo-ch/marketplace-spa/pull/3288). You can compare locally in mspa that bundles came back to the same size as it was before [starting use gihub packages for style-guide](https://github.com/ricardo-ch/style-guide-react/pull/1406), to check bundle size use `yarn build:profile` command.