### PR TITLE
Allow giving a different working_directory for the main jobs for Java deployments

### DIFF
--- a/src/jobs/build_push_image.yml
+++ b/src/jobs/build_push_image.yml
@@ -10,6 +10,10 @@ executor:
   password: <<parameters.private_hub_password>>
 
 parameters:
+  working_directory:
+    description: 'In which directory to run the steps. Will be interpreted as an absolute path.'
+    type: string
+    default: .
   path:
     description: 'Path to directory containing isopod.yml file'
     type: string
@@ -74,8 +78,11 @@ parameters:
     type: string
     default: ""
 
+working_directory: ~/project/<< parameters.working_directory >>
+
 steps:
-  - checkout
+  - checkout:
+      path: ~/project
   # only really needed for maven/java, but less painful to just do it than to configure it in each java build config
   - maven_auth:
       maven_credentials: << parameters.maven_credentials >>

--- a/src/jobs/deploy_job.yml
+++ b/src/jobs/deploy_job.yml
@@ -9,6 +9,10 @@ executor:
   password: <<parameters.private_hub_password>>
 
 parameters:
+  working_directory:
+    description: 'In which directory to run the steps. Will be interpreted as an absolute path.'
+    type: string
+    default: .
   path:
     description: 'Path to directory containing isopod.yml file'
     type: string
@@ -68,8 +72,11 @@ parameters:
     type: string
     default: ""
 
+working_directory: ~/project/<< parameters.working_directory >>
+
 steps:
-  - checkout
+  - checkout:
+      path: ~/project
   - steps: << parameters.predeploy_steps >>
   - deploy:
       config: << parameters.path >>/<< parameters.isopod_config >>

--- a/src/jobs/maven_build_test.yml
+++ b/src/jobs/maven_build_test.yml
@@ -3,6 +3,10 @@ description: >
   Supports app-module from monorepo as well as single app from single-app-repo.
 
 parameters:
+  working_directory:
+    description: 'In which directory to run the steps. Will be interpreted as an absolute path.'
+    type: string
+    default: .
   path:
     description: 'Path of maven module for the app, or "." for single-app-repo'
     type: string
@@ -18,8 +22,11 @@ parameters:
 
 executor: << parameters.executor >>
 
+working_directory: ~/project/<< parameters.working_directory >>
+
 steps:
-  - checkout
+  - checkout:
+      path: ~/project
   - maven_restore_artifacts:
       prefix: << parameters.cache_key_prefix >>
       path: << parameters.path >>


### PR DESCRIPTION
This is a minor version change.