### PR TITLE
Add main as a default "to be notified" branch

### DIFF
--- a/src/examples/go_monorepo_workflows.yml
+++ b/src/examples/go_monorepo_workflows.yml
@@ -153,7 +153,7 @@ usage:
             env: prod
             slack_notify_success: true
             slack_notify_failure: true
-            # FIXME: replace value with your actual main/master branch name; 'master' is default and is not needed for the slack webhook configuration to work
+            # FIXME: replace value with your actual main/master branch name; 'master' and 'main' are both default values are not needed for the slack webhook configuration to work
             #slack_ok_branches: 'main'
             #slack_fail_branches: 'main'
             filters:
@@ -253,7 +253,7 @@ usage:
             env: prod
             slack_notify_success: true
             slack_notify_failure: true
-            # FIXME: replace value with your actual main/master branch name; 'master' is default and is not needed for the slack webhook configuration to work
+            # FIXME: replace value with your actual main/master branch name; 'master' and 'main' are both default values are not needed for the slack webhook configuration to work
             #slack_ok_branches: 'main'
             #slack_fail_branches: 'main'
             filters:

--- a/src/examples/go_singlerepo.yml
+++ b/src/examples/go_singlerepo.yml
@@ -74,7 +74,7 @@ usage:
             env: prod
             slack_notify_success: true
             slack_notify_failure: true
-            # FIXME: replace value with your actual main/master branch name; 'master' is default and is not needed for the slack webhook configuration to work
+            # FIXME: replace value with your actual main/master branch name; 'master' and 'main' are both default values are not needed for the slack webhook configuration to work
             #slack_ok_branches: 'main'
             #slack_fail_branches: 'main'
             filters:

--- a/src/examples/java_monorepo_workflows.yml
+++ b/src/examples/java_monorepo_workflows.yml
@@ -144,7 +144,7 @@ usage:
             env: 'prod'
             slack_notify_success: true
             slack_notify_failure: true
-            # FIXME: replace value with your actual main/master branch name; 'master' is default and is not needed for the slack webhook configuration to work
+            # FIXME: replace value with your actual main/master branch name; 'master' and 'main' are both default values are not needed for the slack webhook configuration to work
             #slack_ok_branches: 'main'
             #slack_fail_branches: 'main'
             filters:
@@ -225,7 +225,7 @@ usage:
             env: 'prod'
             slack_notify_success: true
             slack_notify_failure: true
-            # FIXME: replace value with your actual main/master branch name; 'master' is default and is not needed for the slack webhook configuration to work
+            # FIXME: replace value with your actual main/master branch name; 'master' and 'main' are both default values are not needed for the slack webhook configuration to work
             #slack_ok_branches: 'main'
             #slack_fail_branches: 'main'
             filters:

--- a/src/examples/java_singleapprepo.yml
+++ b/src/examples/java_singleapprepo.yml
@@ -74,7 +74,7 @@ usage:
             env: 'prod'
             slack_notify_success: true
             slack_notify_failure: true
-            # FIXME: replace value with your actual main/master branch name; 'master' is default and is not needed for the slack webhook configuration to work
+            # FIXME: replace value with your actual main/master branch name; 'master' and 'main' are both default values are not needed for the slack webhook configuration to work
             #slack_ok_branches: 'main'
             #slack_fail_branches: 'main'
             filters:

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -224,10 +224,10 @@ jobs:
 - **postdeploy_steps**: steps that are executed after deployment. Default is none
 - **slack_notify_success**: flag to send slack message if job is successful. Default is false
 - **slack_ok_webhook**: the slack webhook used to send slack message on success. Default is value from context variable $SLACK_WEBHOOK
-- **slack_ok_branches**: comma separated list of branches for which successful slack message will be sent. Default is *master*
+- **slack_ok_branches**: comma separated list of branches for which successful slack message will be sent. Default is *master,main*
 - **slack_notify_failure**: flag to send slack message when job fails. Default is false
 - **slack_fail_webhook**: the slack webhook used to send slack message on failure. Default is value from context variable $SLACK_WEBHOOK
-- **slack_fail_branches**: comma separated list of branches for which failure slack message will be sent. Default is *master*
+- **slack_fail_branches**: comma separated list of branches for which failure slack message will be sent. Default is *master,main*
 - **work_dir**: working directory for default deployment (with the isopod). This should be relative to the job working directory. Default is `.`
 
 This job executes deployment on GKE.

--- a/src/jobs/deploy_job.yml
+++ b/src/jobs/deploy_job.yml
@@ -56,7 +56,7 @@ parameters:
   slack_ok_branches:
     description: 'Comma separated list of branches for which notifications are sent'
     type: string
-    default: 'master'
+    default: 'master,main'
   slack_notify_failure:
     description: 'Flag to trigger sending slack notification on failure'
     type: boolean
@@ -67,7 +67,7 @@ parameters:
   slack_fail_branches:
     description: 'Comma separated list of branches for which notifications are sent'
     type: string
-    default: 'master'
+    default: 'master,main'
   image_suffix:
     type: string
     default: ""


### PR DESCRIPTION
This would be a minor release.

---

The `slack_notify_success` / `slack_notify_failure` commands are only executed for a specific list of branches, which only contained `master` by default.
I'm adding `main` as well to the default branches list, to simplify adopting the commands in all our repos.
I adapted the commands, the documentation and the examples.