### PR TITLE
Add node version parameter for JS jobs

### DIFF
--- a/src/executors/js.yml
+++ b/src/executors/js.yml
@@ -7,7 +7,7 @@ docker:
       password: <<parameters.password>>
 parameters:
   node-version:
-    default: 16.15.1
+    default: lts
     description: Node version
     type: string
   username:

--- a/src/jobs/js_build_job.yml
+++ b/src/jobs/js_build_job.yml
@@ -3,7 +3,9 @@ description: >
 
 # Executor
 
-executor: js
+executor:
+  name: js
+  node-version: <<parameters.node-version>>
 
 # Execution
 
@@ -56,3 +58,7 @@ parameters:
     description: some apps doesn't have .env file, e.g. selling-ui
     type: boolean
     default: true
+  node-version:
+    default: lts
+    description: Node version
+    type: string

--- a/src/jobs/js_deploy_storybook.yml
+++ b/src/jobs/js_deploy_storybook.yml
@@ -3,7 +3,9 @@ description: >
 
 # Executor
 
-executor: js
+executor:
+  name: js
+  node-version: <<parameters.node-version>>
 
 # Execution
 
@@ -28,3 +30,7 @@ parameters:
     enum:
       ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "medium"
+  node-version:
+    default: lts
+    description: Node version
+    type: string

--- a/src/jobs/js_install_dependencies_job.yml
+++ b/src/jobs/js_install_dependencies_job.yml
@@ -3,7 +3,9 @@ description: >
 
 # Executor
 
-executor: js
+executor:
+  name: js
+  node-version: <<parameters.node-version>>
 
 # Execution
 
@@ -16,3 +18,11 @@ steps:
       root: .
       paths:
         - node_modules
+
+# Parameters
+
+parameters:
+  node-version:
+    default: lts
+    description: Node version
+    type: string

--- a/src/jobs/js_jest_runner_job.yml
+++ b/src/jobs/js_jest_runner_job.yml
@@ -2,7 +2,9 @@ description: Runs jest tests with CircleCI parallelism
 
 # Executor
 
-executor: js
+executor:
+  name: js
+  node-version: <<parameters.node-version>>
 
 # Execution
 
@@ -51,3 +53,7 @@ parameters:
   jest_options:
     type: string
     default: ''
+  node-version:
+    default: lts
+    description: Node version
+    type: string

--- a/src/jobs/js_lint_runner_job.yml
+++ b/src/jobs/js_lint_runner_job.yml
@@ -2,7 +2,9 @@ description: Runs jest tests with CircleCI parallelism
 
 # Executor
 
-executor: js
+executor:
+  name: js
+  node-version: <<parameters.node-version>>
 
 # Execution
 
@@ -44,3 +46,7 @@ parameters:
   eslint_options:
     type: string
     default: ''
+  node-version:
+    default: lts
+    description: Node version
+    type: string

--- a/src/jobs/js_publish_npm_module_job.yml
+++ b/src/jobs/js_publish_npm_module_job.yml
@@ -78,8 +78,6 @@ steps:
                 # we will publish from ./build folder
                 cd build
 
-                cat package.json
-
                 npm publish
               fi
         - run:

--- a/src/jobs/js_publish_npm_module_job.yml
+++ b/src/jobs/js_publish_npm_module_job.yml
@@ -78,6 +78,8 @@ steps:
                 # we will publish from ./build folder
                 cd build
 
+                cat package.json
+
                 npm publish
               fi
         - run:

--- a/src/jobs/js_publish_npm_module_job.yml
+++ b/src/jobs/js_publish_npm_module_job.yml
@@ -3,7 +3,9 @@ description: >
 
 # Executor
 
-executor: js
+executor:
+  name: js
+  node-version: <<parameters.node-version>>
 
 # Execution
 
@@ -103,3 +105,7 @@ parameters:
     enum: ['np', 'custom']
     default: np
     description: Which tool should be used to publish. This is temporary param and will be removed once we get rid of np module from all our apps
+  node-version:
+    default: lts
+    description: Node version
+    type: string

--- a/src/jobs/js_yarn_runner_job.yml
+++ b/src/jobs/js_yarn_runner_job.yml
@@ -3,7 +3,9 @@ description: >
 
 # Executor
 
-executor: js
+executor:
+  name: js
+  node-version: <<parameters.node-version>>
 
 # Execution
 
@@ -45,3 +47,7 @@ parameters:
   reports_path:
     type: string
     default: ''
+  node-version:
+    default: lts
+    description: Node version
+    type: string


### PR DESCRIPTION
All jobs with js executor now accepts `node_version` optional parameter. The default value is now `lts`, so it will be a breaking change.

**SEMVER Update Type:**
- [x] Major
- [ ] Minor
- [ ] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  ISSUE URL

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.