### PR TITLE
feat(executors): add python executor

### DIFF
--- a/src/executors/python.yml
+++ b/src/executors/python.yml
@@ -1,0 +1,26 @@
+description: |
+  Python executor using [CircleCI images](https://circleci.com/developer/images/image/cimg/python)
+docker:
+  - image: cimg/python:<< parameters.python-version >><< parameters.variant >>
+    auth:
+      username: <<parameters.username>>
+      password: <<parameters.password>>
+parameters:
+  python-version:
+    default: "3.10"
+    description: |
+      The version of Python to use. This can be a full SemVer point release (such as 3.8.1) or just the minor release (such as 3.8).
+    type: string
+  variant:
+    default: ""
+    description: |
+      Variant tags, if available, can optionally be used. For example, the Node.js variant could be used like this: "-node"
+    type: string
+  username:
+    type: string
+    description: Docker hub username
+    default: $DOCKER_HUB_USERNAME
+  password:
+    type: string
+    description: Docker hub password
+    default: $DOCKER_HUB_PASSWORD


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Add a new executor for Python images. Allows to use the CircleCI images with docker hub default credentials.

Usage:
```yaml
executor: 
  name: ric-orb/python
  python-version: "3.10.12"
```

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  ISSUE URL

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.