### PR TITLE
Js monorepo

### DIFF
--- a/src/jobs/js_install_dependencies_job.yml
+++ b/src/jobs/js_install_dependencies_job.yml
@@ -7,19 +7,20 @@ executor:
   name: js
   node-version: <<parameters.node-version>>
 
+working_directory: ~/project/<< parameters.working_directory >>
+
 # Execution
 
 steps:
-  - checkout
+  - checkout:
+      path: ~/project
   - run:
       name: Install dependencies
-      command: |
-        cd << parameters.monorepoAppPath >>
-        yarn --immutable
+      command: yarn --immutable
   - persist_to_workspace:
       root: .
       paths:
-        - << parameters.monorepoAppPath >>/node_modules
+        - node_modules
 
 # Parameters
 
@@ -28,6 +29,6 @@ parameters:
     default: lts
     description: Node version
     type: string
-  monorepoAppPath:
+  working_directory: 
     type: string
-    default: '.'
+    default: ''

--- a/src/jobs/js_install_dependencies_job.yml
+++ b/src/jobs/js_install_dependencies_job.yml
@@ -29,6 +29,6 @@ parameters:
     default: lts
     description: Node version
     type: string
-  working_directory: 
+  working_directory:
     type: string
     default: ''

--- a/src/jobs/js_install_dependencies_job.yml
+++ b/src/jobs/js_install_dependencies_job.yml
@@ -13,11 +13,13 @@ steps:
   - checkout
   - run:
       name: Install dependencies
-      command: yarn --immutable
+      command: |
+        cd << parameters.monorepoAppPath >>
+        yarn --immutable
   - persist_to_workspace:
       root: .
       paths:
-        - node_modules
+        - << parameters.monorepoAppPath >>/node_modules
 
 # Parameters
 
@@ -26,3 +28,6 @@ parameters:
     default: lts
     description: Node version
     type: string
+  monorepoAppPath:
+    type: string
+    default: '.'

--- a/src/jobs/js_push_build_to_bucket_job.yml
+++ b/src/jobs/js_push_build_to_bucket_job.yml
@@ -6,12 +6,8 @@ docker:
   - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
 
 steps:
-  - when:
-      condition:
-        equal: [ true, << parameters.do_checkout >> ]
-      steps:
-        # in auth0 build files are committed
-        - checkout
+  
+  # in auth0 build files are committed
   - checkout
   - attach_workspace:
       at: .
@@ -37,6 +33,3 @@ parameters:
     type: string
   source:
     type: string
-  do_checkout:
-    type: boolean
-    default: false

--- a/src/jobs/js_push_build_to_bucket_job.yml
+++ b/src/jobs/js_push_build_to_bucket_job.yml
@@ -6,6 +6,13 @@ docker:
   - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
 
 steps:
+  - when:
+      condition:
+        equal: [ true, << parameters.do_checkout >> ]
+      steps:
+        # in auth0 build files are committed
+        - checkout
+  - checkout
   - attach_workspace:
       at: .
   - run:
@@ -30,3 +37,6 @@ parameters:
     type: string
   source:
     type: string
+  do_checkout:
+    type: boolean
+    default: false

--- a/src/jobs/js_push_build_to_bucket_job.yml
+++ b/src/jobs/js_push_build_to_bucket_job.yml
@@ -6,7 +6,7 @@ docker:
   - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
 
 steps:
-  
+
   # in auth0 build files are committed
   - checkout
   - attach_workspace:

--- a/src/jobs/js_push_build_to_bucket_job.yml
+++ b/src/jobs/js_push_build_to_bucket_job.yml
@@ -6,7 +6,6 @@ docker:
   - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
 
 steps:
-
   # in auth0 build files are committed
   - checkout
   - attach_workspace:

--- a/src/jobs/js_yarn_runner_job.yml
+++ b/src/jobs/js_yarn_runner_job.yml
@@ -25,7 +25,7 @@ steps:
                   environment:
                     JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
         - unless:
-            condition: << parameters.reports_path >>
+            condition: << parameters.monorepo >>
             steps:
               - run:
                   name: Running tests

--- a/src/jobs/js_yarn_runner_job.yml
+++ b/src/jobs/js_yarn_runner_job.yml
@@ -18,7 +18,9 @@ steps:
       steps:
         - run:
             name: Running yarn command
-            command: cd << parameters.monorepo >> && yarn << parameters.script >>
+            command: |
+              cd << parameters.monorepoAppPath >>
+              yarn << parameters.script >>
             environment:
               JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
         - store_test_results:
@@ -30,7 +32,9 @@ steps:
       steps:
         - run:
             name: Running yarn command
-            command: cd << parameters.monorepo >> && yarn << parameters.script >>
+            command: |
+              cd << parameters.monorepoAppPath >>
+              yarn << parameters.script >>
 
 # generic CircleCI params
 
@@ -51,6 +55,6 @@ parameters:
     default: lts
     description: Node version
     type: string
-  monorepo:
+  monorepoAppPath:
     type: string
     default: '.'

--- a/src/jobs/js_yarn_runner_job.yml
+++ b/src/jobs/js_yarn_runner_job.yml
@@ -7,10 +7,13 @@ executor:
   name: js
   node-version: <<parameters.node-version>>
 
+working_directory: ~/project/<< parameters.working_directory >>
+
 # Execution
 
 steps:
-  - checkout
+  - checkout:
+      path: ~/project
   - attach_workspace:
       at: .
   - when:
@@ -18,9 +21,7 @@ steps:
       steps:
         - run:
             name: Running yarn command
-            command: |
-              cd << parameters.monorepoAppPath >>
-              yarn << parameters.script >>
+            command: yarn << parameters.script >>
             environment:
               JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
         - store_test_results:
@@ -32,9 +33,7 @@ steps:
       steps:
         - run:
             name: Running yarn command
-            command: |
-              cd << parameters.monorepoAppPath >>
-              yarn << parameters.script >>
+            command: yarn << parameters.script >>
 
 # generic CircleCI params
 
@@ -55,6 +54,6 @@ parameters:
     default: lts
     description: Node version
     type: string
-  monorepoAppPath:
+  working_directory: 
     type: string
-    default: '.'
+    default: ''

--- a/src/jobs/js_yarn_runner_job.yml
+++ b/src/jobs/js_yarn_runner_job.yml
@@ -16,11 +16,22 @@ steps:
   - when:
       condition: << parameters.reports_path >>
       steps:
-        - run:
-            name: Running tests
-            command: yarn << parameters.script >>
-            environment:
-              JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
+        - when:
+            condition: << parameters.monorepo >>
+            steps:
+              - run:
+                  name: Running tests
+                  command: cd << parameters.monorepo >> && yarn << parameters.script >>
+                  environment:
+                    JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
+        - unless:
+            condition: << parameters.reports_path >>
+            steps:
+              - run:
+                  name: Running tests
+                  command: yarn << parameters.script >>
+                  environment:
+                    JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
         - store_test_results:
             path: << parameters.reports_path >>
         - store_artifacts:
@@ -51,3 +62,6 @@ parameters:
     default: lts
     description: Node version
     type: string
+  monorepo:
+    type: string
+    default: ''

--- a/src/jobs/js_yarn_runner_job.yml
+++ b/src/jobs/js_yarn_runner_job.yml
@@ -16,22 +16,11 @@ steps:
   - when:
       condition: << parameters.reports_path >>
       steps:
-        - when:
-            condition: << parameters.monorepo >>
-            steps:
-              - run:
-                  name: Running tests
-                  command: cd << parameters.monorepo >> && yarn << parameters.script >>
-                  environment:
-                    JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
-        - unless:
-            condition: << parameters.monorepo >>
-            steps:
-              - run:
-                  name: Running tests
-                  command: yarn << parameters.script >>
-                  environment:
-                    JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
+        - run:
+            name: Running tests
+            command: cd << parameters.monorepo >> && yarn << parameters.script >>
+            environment:
+              JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
         - store_test_results:
             path: << parameters.reports_path >>
         - store_artifacts:
@@ -64,4 +53,4 @@ parameters:
     type: string
   monorepo:
     type: string
-    default: ''
+    default: '.'

--- a/src/jobs/js_yarn_runner_job.yml
+++ b/src/jobs/js_yarn_runner_job.yml
@@ -17,7 +17,7 @@ steps:
       condition: << parameters.reports_path >>
       steps:
         - run:
-            name: Running tests
+            name: Running yarn command
             command: cd << parameters.monorepo >> && yarn << parameters.script >>
             environment:
               JEST_JUNIT_OUTPUT_DIR: << parameters.reports_path >>
@@ -29,8 +29,8 @@ steps:
       condition: << parameters.reports_path >>
       steps:
         - run:
-            name: Running tests
-            command: yarn << parameters.script >>
+            name: Running yarn command
+            command: cd << parameters.monorepo >> && yarn << parameters.script >>
 
 # generic CircleCI params
 

--- a/src/jobs/js_yarn_runner_job.yml
+++ b/src/jobs/js_yarn_runner_job.yml
@@ -54,6 +54,6 @@ parameters:
     default: lts
     description: Node version
     type: string
-  working_directory: 
+  working_directory:
     type: string
     default: ''


### PR DESCRIPTION
Add monorepo support for some js jobs:

`js_install_dependencies_job.yml` - solves issue of not having ci config in the app root
`js_yarn_runner_job.yml` - same as above
`js_push_build_to_bucket_job.yml` - in auth0, for now build files are versioned, so wee need to checkout before pushing assets