### PR TITLE
Add tag parameter for executor maven_vm

### DIFF
--- a/src/executors/maven_vm.yml
+++ b/src/executors/maven_vm.yml
@@ -2,5 +2,12 @@ description: >
   VM executor with JDK 11 to build java applications.
   Typically required if maven build needs docker for testcontainers.
 
+parameters:
+  tag:
+    default: 'current'
+    description: >
+      Pick a specific ubuntu-2204 image version
+    type: string
+
 machine:
-  image: 'ubuntu-2204:current'
+  image: 'ubuntu-2204:<< parameters.tag >>'


### PR DESCRIPTION
(it should be a minor release)
Otherwise we always depend on the `current` tag of the Ubuntu image, that might change the default Java version under the hood.
See details in [thread](https://swissmarketplace.enterprise.slack.com/archives/C043ZRKHJ2Y/p1715165362105559)