### PR TITLE
adding two context names

### DIFF
--- a/src/scripts/authenticate.sh
+++ b/src/scripts/authenticate.sh
@@ -5,7 +5,8 @@ gcloud --quiet config set project "${GOOGLE_PROJECT_ID}"
 gcloud --quiet config set compute/zone "${GKE_COMPUTE_ZONE}"
 gcloud --quiet container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_COMPUTE_ZONE}"
 kubectl config rename-context gke_"${GOOGLE_PROJECT_ID}"_"${GKE_COMPUTE_ZONE}"_"${GKE_CLUSTER_NAME}" "${GKE_CLUSTER_NAME}"
-# If cluster is a "dev-banana" cluster, pull it again and rename it to "dev-cookie". Required for isopod to work
+# If cluster is a "dev-banana" cluster, pull it again and rename it to "dev-cookie". Required for isopod as isopod uses "dev-cookie" context.
+# other steps like port-forward will fail if the context is "dev-cookie".
 if [ "${GKE_CLUSTER_NAME}" = "dev-banana" ]; then
   gcloud --quiet container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_COMPUTE_ZONE}"
   kubectl config rename-context gke_"${GOOGLE_PROJECT_ID}"_"${GKE_COMPUTE_ZONE}"_"${GKE_CLUSTER_NAME}" "dev-cookie"

--- a/src/scripts/authenticate.sh
+++ b/src/scripts/authenticate.sh
@@ -5,7 +5,9 @@ gcloud --quiet config set project "${GOOGLE_PROJECT_ID}"
 gcloud --quiet config set compute/zone "${GKE_COMPUTE_ZONE}"
 gcloud --quiet container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_COMPUTE_ZONE}"
 kubectl config rename-context gke_"${GOOGLE_PROJECT_ID}"_"${GKE_COMPUTE_ZONE}"_"${GKE_CLUSTER_NAME}" "${GKE_CLUSTER_NAME}"
-# rename context from dev-banana to dev-cookie because isopod do not recognize dev-banana
+# If cluster is a "dev-banana" cluster, pull it again and rename it to "dev-cookie". Required for isopod to work
 if [ "${GKE_CLUSTER_NAME}" = "dev-banana" ]; then
+  gcloud --quiet container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_COMPUTE_ZONE}"
+  kubectl config rename-context gke_"${GOOGLE_PROJECT_ID}"_"${GKE_COMPUTE_ZONE}"_"${GKE_CLUSTER_NAME}" "${GKE_CLUSTER_NAME}"
   kubectl config rename-context "${GKE_CLUSTER_NAME}" "dev-cookie"
 fi

--- a/src/scripts/authenticate.sh
+++ b/src/scripts/authenticate.sh
@@ -8,6 +8,5 @@ kubectl config rename-context gke_"${GOOGLE_PROJECT_ID}"_"${GKE_COMPUTE_ZONE}"_"
 # If cluster is a "dev-banana" cluster, pull it again and rename it to "dev-cookie". Required for isopod to work
 if [ "${GKE_CLUSTER_NAME}" = "dev-banana" ]; then
   gcloud --quiet container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_COMPUTE_ZONE}"
-  kubectl config rename-context gke_"${GOOGLE_PROJECT_ID}"_"${GKE_COMPUTE_ZONE}"_"${GKE_CLUSTER_NAME}" "${GKE_CLUSTER_NAME}"
-  kubectl config rename-context "${GKE_CLUSTER_NAME}" "dev-cookie"
+  kubectl config rename-context gke_"${GOOGLE_PROJECT_ID}"_"${GKE_COMPUTE_ZONE}"_"${GKE_CLUSTER_NAME}" "dev-cookie"
 fi


### PR DESCRIPTION
Isopod requires the context name dev-cookie, while some other steps do not. For this reason, we pull dev-banana credentials and keep them locally under the names dev-cookie and dev-banana. This fix removes the need for changes in CICD pipelines after switching to dev-banana,